### PR TITLE
Excloude eng folder from the sonar report

### DIFF
--- a/.github/workflows/sonar-spring-cloud-azure.yml
+++ b/.github/workflows/sonar-spring-cloud-azure.yml
@@ -27,9 +27,19 @@ jobs:
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-      #- name: Installing the build tools
-      #  run: mvn install -f eng/code-quality-reports/pom.xml 
+          restore-keys: ${{ runner.os }}-sonar    
+      - name: Installing the build tools and dependencies
+        run: |
+          mvn clean install \
+          -Dcheckstyle.skip=true \
+          -Dcodesnippet.skip \
+          -Denforcer.skip \
+          -Djacoco.skip=true \
+          -Dmaven.javadoc.skip=true \
+          -Drevapi.skip=true \
+          -DskipTests \
+          -Dspotbugs.skip=true \
+          -T 4 -ntp -Pdev -f sdk/spring/pom.xml
       #- name: Building and Testing
        # run: mvn install -f pom.xml -Dcheckstyle.skip -Dgpg.skip -Dmaven.javadoc.skip -Drevapi.skip -DskipSpringITs -DskipTests -Dspotbugs.skip -Djacoco.skip
       - name: Build and analyze
@@ -40,5 +50,10 @@ jobs:
           JAVA_OPTS: "-Xmx3062m -XX:MaxPermSize=512m -XX:ReservedCodeCacheSize=128m"
           SONAR_SCANNER_OPTS: "-Xmx3062m -XX:MaxPermSize=512m -XX:ReservedCodeCacheSize=128m"
           MAVEN_OPTS: "-Xmx3062m -XX:MaxPermSize=512m -XX:ReservedCodeCacheSize=128m"
-        run: mvn -B -e -f sdk/spring/pom.xml -P dev verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.organization=stliu -Dsonar.host.url=https://sonarcloud.io -Dsonar.projectKey=stliu_azure-sdk-for-java -Dsonar.exclusions=eng/** -Dgpg.skip -Dmaven.javadoc.skip -Drevapi.skip  
+        run: |
+          mvn -B -e -f sdk/spring/pom.xml -P coverage verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+          -Dsonar.organization=stliu \
+          -Dsonar.host.url=https://sonarcloud.io \
+          -Dsonar.projectKey=stliu_azure-sdk-for-java \
+          -Dgpg.skip -Dmaven.javadoc.skip -Drevapi.skip  
 


### PR DESCRIPTION
As subject. 

There're two approaches to exclude the folder:
- Add `-Dsonar.exclusions=eng/**`  to the maven build command
- Use another profile to build only the spring libraries having source codes. 

This PR will choose the second one, so the code of eng/ folder won't show on the report at all.

Refs:
https://stackoverflow.com/questions/21425012/configure-sonar-to-exclude-files-from-maven-pom-xml
https://community.sonarsource.com/t/sonarcloud-doesnt-exclude-specific-folder/36852/6