### PR TITLE
Fix github action not update to 2.x.x

### DIFF
--- a/.github/workflows/update-spring-cloud-azure-support-file.yml
+++ b/.github/workflows/update-spring-cloud-azure-support-file.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           PULL_REQUEST_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           PULL_REQUEST_REPOSITORY: Azure/azure-sdk-for-java
-          PULL_REQUEST_TITLE: "Update Spring Cloud Azure Support File"
+          PULL_REQUEST_TITLE: "Update Spring Boot and Spring Cloud versions for the Spring compatibility tests"
           PULL_REQUEST_FROM_BRANCH: "${{ secrets.USER }}:update-spring-cloud-azure-support-file"
           PULL_REQUEST_BRANCH: "main"
           PULL_REQUEST_BODY: "Update Spring Boot and Spring Cloud versions for the compatibility test.\n\nIf you merged this PR, please update [Spring Cloud Azure Timeline](https://github.com/Azure/azure-sdk-for-java/wiki/Spring-Cloud-Azure-Timeline).\n\nThis PR is created by GitHub Actions: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"

--- a/src/main/java/com/azure/spring/dev/tools/dependency/support/SpringProjectMetadataReader.java
+++ b/src/main/java/com/azure/spring/dev/tools/dependency/support/SpringProjectMetadataReader.java
@@ -2,6 +2,7 @@ package com.azure.spring.dev.tools.dependency.support;
 
 import com.azure.spring.dev.tools.dependency.configuration.DependencyProperties;
 import com.azure.spring.dev.tools.dependency.metadata.spring.ProjectRelease;
+import com.azure.spring.dev.tools.dependency.metadata.spring.ReleaseStatus;
 import com.azure.spring.dev.tools.dependency.metadata.spring.SpringReleaseMetadata;
 import org.springframework.web.client.RestTemplate;
 
@@ -40,7 +41,8 @@ public class SpringProjectMetadataReader {
     public String getCurrentVersion() {
         return getProjectReleases("spring-boot")
             .stream()
-            .filter(p -> p.isCurrent())
+            .filter(p -> p.getReleaseStatus().equals(ReleaseStatus.GENERAL_AVAILABILITY))
+            .filter(p -> p.getVersion().matches("2\\.\\d\\.\\d+"))
             .filter(Objects::nonNull)
             .map(ProjectRelease::getVersion)
             .findFirst()


### PR DESCRIPTION
## Context
This GitHub action is trying to auto-update to the latest Spring Boot and Spring Cloud versions for Spring Cloud Azure.

Before Spring3.0 release:
We use the version with `current` status in this [metadata](https://spring.io/project_metadata/spring-boot), at that time, it always will be the "2.x.x", so our auto-update action is ok.

After Spring3.0 release:
In this [metadata](https://spring.io/project_metadata/spring-boot), the `current` status was move to "3.x.x"
<img width="447" alt="image" src="https://user-images.githubusercontent.com/92105726/203938813-edc2e043-cd78-4f3f-a31f-56a4893f7b1c.png">
so the action will update to "3.x.x".

## Goal
Fix the GitHub action to make it update to Spring Boot 2.x.