### PR TITLE
Fix GitHub action to set 2.7.x as current

### DIFF
--- a/src/main/java/com/azure/spring/dev/tools/dependency/support/converter/SpringCloudAzureSupportMetadataConverter.java
+++ b/src/main/java/com/azure/spring/dev/tools/dependency/support/converter/SpringCloudAzureSupportMetadataConverter.java
@@ -2,6 +2,7 @@ package com.azure.spring.dev.tools.dependency.support.converter;
 
 import com.azure.spring.dev.tools.dependency.metadata.azure.SpringCloudAzureSupportMetadata;
 import com.azure.spring.dev.tools.dependency.metadata.spring.ProjectRelease;
+import com.azure.spring.dev.tools.dependency.metadata.spring.ReleaseStatus;
 import org.springframework.core.convert.converter.Converter;
 
 /**
@@ -23,9 +24,13 @@ public class SpringCloudAzureSupportMetadataConverter implements Converter<Proje
     @Override
     public SpringCloudAzureSupportMetadata convert(ProjectRelease source) {
         SpringCloudAzureSupportMetadata springCloudAzureSupportMetadata = new SpringCloudAzureSupportMetadata();
-        springCloudAzureSupportMetadata.setCurrent(source.isCurrent());
+        springCloudAzureSupportMetadata.setCurrent(false);
         springCloudAzureSupportMetadata.setSpringBootVersion(source.getVersion());
         springCloudAzureSupportMetadata.setReleaseStatus(source.getReleaseStatus());
+        if (source.getReleaseStatus().equals(ReleaseStatus.GENERAL_AVAILABILITY) &&
+            source.getVersion().matches("2\\.7\\.\\d+")) {
+            springCloudAzureSupportMetadata.setCurrent(true);
+        }
         springCloudAzureSupportMetadata.setSnapshot(source.isSnapshot());
 
         return springCloudAzureSupportMetadata;


### PR DESCRIPTION
### Context 
This GitHub action is to update `spring-cloud-azure-supported-spring.json` for Spring Compatibility tests.

Before Spring3.0 release:
We use the version with `current` status in this [metadata](https://spring.io/project_metadata/spring-boot) as our current version, at that time, it always will be the "2.x.x", so our action is ok.

After Spring3.0 release:
In this [metadata](https://spring.io/project_metadata/spring-boot), the `current` status was move to "3.x.x"
<img width="447" alt="image" src="https://user-images.githubusercontent.com/92105726/203938813-edc2e043-cd78-4f3f-a31f-56a4893f7b1c.png">
so the action will set "3.x.x" as our current version, this does not meet our requirements.

## Goal
Fix the GitHub action to make it reset Spring Boot 2.x as our current version