### PR TITLE
Update Logic of getting Spring Boot current version

### DIFF
--- a/src/main/java/com/azure/spring/dev/tools/dependency/support/SpringProjectMetadataReader.java
+++ b/src/main/java/com/azure/spring/dev/tools/dependency/support/SpringProjectMetadataReader.java
@@ -1,6 +1,7 @@
 package com.azure.spring.dev.tools.dependency.support;
 
 import com.azure.spring.dev.tools.dependency.configuration.DependencyProperties;
+import com.azure.spring.dev.tools.dependency.metadata.maven.VersionParser;
 import com.azure.spring.dev.tools.dependency.metadata.spring.ProjectRelease;
 import com.azure.spring.dev.tools.dependency.metadata.spring.ReleaseStatus;
 import com.azure.spring.dev.tools.dependency.metadata.spring.SpringReleaseMetadata;
@@ -9,8 +10,6 @@ import org.springframework.web.client.RestTemplate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-
-import static com.azure.spring.dev.tools.dependency.metadata.maven.VersionParser.DEFAULT;
 
 /**
  * Read a Spring project's metadata from https://spring.io/project_metadata endpoint.
@@ -47,7 +46,7 @@ public class SpringProjectMetadataReader {
             .filter(p -> p.getReleaseStatus().equals(ReleaseStatus.GENERAL_AVAILABILITY))
             .filter(p -> p.getVersion().matches("2\\.\\d\\.\\d+"))
             .map(ProjectRelease::getVersion)
-            .map(DEFAULT::parse)
+            .map(VersionParser.DEFAULT::parse)
             .sorted(Comparator.reverseOrder())
             .filter(Objects::nonNull)
             .findFirst()

--- a/src/main/java/com/azure/spring/dev/tools/dependency/support/SpringProjectMetadataReader.java
+++ b/src/main/java/com/azure/spring/dev/tools/dependency/support/SpringProjectMetadataReader.java
@@ -1,7 +1,6 @@
 package com.azure.spring.dev.tools.dependency.support;
 
 import com.azure.spring.dev.tools.dependency.configuration.DependencyProperties;
-import com.azure.spring.dev.tools.dependency.metadata.maven.Version;
 import com.azure.spring.dev.tools.dependency.metadata.spring.ProjectRelease;
 import com.azure.spring.dev.tools.dependency.metadata.spring.ReleaseStatus;
 import com.azure.spring.dev.tools.dependency.metadata.spring.SpringReleaseMetadata;
@@ -48,15 +47,11 @@ public class SpringProjectMetadataReader {
             .filter(p -> p.getReleaseStatus().equals(ReleaseStatus.GENERAL_AVAILABILITY))
             .filter(p -> p.getVersion().matches("2\\.\\d\\.\\d+"))
             .map(ProjectRelease::getVersion)
-            .map(this::parse)
+            .map(DEFAULT::parse)
             .sorted(Comparator.reverseOrder())
             .filter(Objects::nonNull)
             .findFirst()
             .get()
             .toString();
-    }
-
-    private Version parse(String version) {
-        return DEFAULT.parse(version);
     }
 }

--- a/src/main/java/com/azure/spring/dev/tools/dependency/support/SpringProjectMetadataReader.java
+++ b/src/main/java/com/azure/spring/dev/tools/dependency/support/SpringProjectMetadataReader.java
@@ -1,13 +1,19 @@
 package com.azure.spring.dev.tools.dependency.support;
 
 import com.azure.spring.dev.tools.dependency.configuration.DependencyProperties;
+import com.azure.spring.dev.tools.dependency.metadata.maven.Version;
+import com.azure.spring.dev.tools.dependency.metadata.maven.VersionParser;
 import com.azure.spring.dev.tools.dependency.metadata.spring.ProjectRelease;
 import com.azure.spring.dev.tools.dependency.metadata.spring.ReleaseStatus;
 import com.azure.spring.dev.tools.dependency.metadata.spring.SpringReleaseMetadata;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.azure.spring.dev.tools.dependency.metadata.maven.VersionParser.DEFAULT;
 
 /**
  * Read a Spring project's metadata from https://spring.io/project_metadata endpoint.
@@ -43,9 +49,17 @@ public class SpringProjectMetadataReader {
             .stream()
             .filter(p -> p.getReleaseStatus().equals(ReleaseStatus.GENERAL_AVAILABILITY))
             .filter(p -> p.getVersion().matches("2\\.\\d\\.\\d+"))
-            .filter(Objects::nonNull)
             .map(ProjectRelease::getVersion)
+            .map(this::parse)
+            .sorted(Comparator.reverseOrder())
+            .collect(Collectors.toList())
+            .stream()
             .findFirst()
-            .get();
+            .get()
+            .toString();
+    }
+
+    private Version parse(String version) {
+        return DEFAULT.parse(version);
     }
 }

--- a/src/main/java/com/azure/spring/dev/tools/dependency/support/SpringProjectMetadataReader.java
+++ b/src/main/java/com/azure/spring/dev/tools/dependency/support/SpringProjectMetadataReader.java
@@ -2,7 +2,6 @@ package com.azure.spring.dev.tools.dependency.support;
 
 import com.azure.spring.dev.tools.dependency.configuration.DependencyProperties;
 import com.azure.spring.dev.tools.dependency.metadata.maven.Version;
-import com.azure.spring.dev.tools.dependency.metadata.maven.VersionParser;
 import com.azure.spring.dev.tools.dependency.metadata.spring.ProjectRelease;
 import com.azure.spring.dev.tools.dependency.metadata.spring.ReleaseStatus;
 import com.azure.spring.dev.tools.dependency.metadata.spring.SpringReleaseMetadata;
@@ -11,7 +10,6 @@ import org.springframework.web.client.RestTemplate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static com.azure.spring.dev.tools.dependency.metadata.maven.VersionParser.DEFAULT;
 
@@ -52,8 +50,7 @@ public class SpringProjectMetadataReader {
             .map(ProjectRelease::getVersion)
             .map(this::parse)
             .sorted(Comparator.reverseOrder())
-            .collect(Collectors.toList())
-            .stream()
+            .filter(Objects::nonNull)
             .findFirst()
             .get()
             .toString();


### PR DESCRIPTION
Since [spring-boot metadata](https://api.spring.io/project_metadata/spring-boot) changes the order of the Spring Boot versions, we need to add logic to ensure that the correct version is obtained.