### PR TITLE
Fix `Update Spring Cloud Azure Support File` action failed

### DIFF
--- a/src/main/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunner.java
+++ b/src/main/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunner.java
@@ -115,7 +115,6 @@ public class UpdateSpringCloudAzureSupportFileRunner implements CommandLineRunne
         if (supportMetadata != null && supportMetadata.getSupportStatus() == SupportStatus.END_OF_LIFE) {
             return supportMetadata.getSpringCloudVersion();
         }
-
         return this.springCloudCompatibleSpringBootVersionRanges
             .entrySet()
             .stream()

--- a/src/main/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunner.java
+++ b/src/main/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunner.java
@@ -122,7 +122,7 @@ public class UpdateSpringCloudAzureSupportFileRunner implements CommandLineRunne
                 .filter(entry -> entry.getValue().match(Version.parse(springBootVersion)))
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList())
-                .stream().findFirst().orElseThrow();
+                .stream().findFirst().get();
         } catch (Exception e) {
             LOGGER.info("Spring Boot " + springBootVersion + " does not support yet, so skip it");
         }

--- a/src/main/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunner.java
+++ b/src/main/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunner.java
@@ -115,18 +115,14 @@ public class UpdateSpringCloudAzureSupportFileRunner implements CommandLineRunne
         if (supportMetadata != null && supportMetadata.getSupportStatus() == SupportStatus.END_OF_LIFE) {
             return supportMetadata.getSpringCloudVersion();
         }
-        try {
-            return this.springCloudCompatibleSpringBootVersionRanges
-                .entrySet()
-                .stream()
-                .filter(entry -> entry.getValue().match(Version.parse(springBootVersion)))
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toList())
-                .stream().findFirst().get();
-        } catch (Exception e) {
-            LOGGER.info("Spring Boot " + springBootVersion + " does not support yet, so skip it");
-        }
-        return "not get the supported Spring Cloud version yet";
+
+        return this.springCloudCompatibleSpringBootVersionRanges
+            .entrySet()
+            .stream()
+            .filter(entry -> entry.getValue().match(Version.parse(springBootVersion)))
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toList())
+            .stream().findFirst().orElse("NONE_SUPPORTED_SPRING_CLOUD_VERSION");
     }
 
 }

--- a/src/main/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunner.java
+++ b/src/main/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunner.java
@@ -115,13 +115,18 @@ public class UpdateSpringCloudAzureSupportFileRunner implements CommandLineRunne
         if (supportMetadata != null && supportMetadata.getSupportStatus() == SupportStatus.END_OF_LIFE) {
             return supportMetadata.getSpringCloudVersion();
         }
-        return this.springCloudCompatibleSpringBootVersionRanges
-            .entrySet()
-            .stream()
-            .filter(entry -> entry.getValue().match(Version.parse(springBootVersion)))
-            .map(Map.Entry::getKey)
-            .collect(Collectors.toList())
-            .stream().findFirst().orElseThrow();
+        try {
+            return this.springCloudCompatibleSpringBootVersionRanges
+                .entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().match(Version.parse(springBootVersion)))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList())
+                .stream().findFirst().orElseThrow();
+        } catch (Exception e) {
+            LOGGER.info("Spring Boot " + springBootVersion + " does not support yet, so skip it");
+        }
+        return "not get the supported Spring Cloud version yet";
     }
 
 }

--- a/src/main/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunner.java
+++ b/src/main/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunner.java
@@ -40,6 +40,7 @@ import static com.azure.spring.dev.tools.dependency.support.converter.SpringClou
 @Component
 public class UpdateSpringCloudAzureSupportFileRunner implements CommandLineRunner {
     private static final Logger LOGGER = LoggerFactory.getLogger(UpdateSpringCloudAzureSupportFileRunner.class);
+    static final String NONE_SUPPORTED_VERSION = "NONE_SUPPORTED_SPRING_CLOUD_VERSION";
     private final SpringProjectMetadataReader springProjectMetadataReader;
     private final Map<String, VersionRange> springCloudCompatibleSpringBootVersionRanges;
     private final Map<String, SpringCloudAzureSupportMetadata> azureSupportMetadataMap;
@@ -110,7 +111,7 @@ public class UpdateSpringCloudAzureSupportFileRunner implements CommandLineRunne
         return supportMetadata == null ? null : supportMetadata.getSupportStatus();
     }
 
-    private String findCompatibleSpringCloudVersion(String springBootVersion) {
+    String findCompatibleSpringCloudVersion(String springBootVersion) {
         SpringCloudAzureSupportMetadata supportMetadata = this.azureSupportMetadataMap.get(springBootVersion);
         if (supportMetadata != null && supportMetadata.getSupportStatus() == SupportStatus.END_OF_LIFE) {
             return supportMetadata.getSpringCloudVersion();
@@ -121,7 +122,7 @@ public class UpdateSpringCloudAzureSupportFileRunner implements CommandLineRunne
             .filter(entry -> entry.getValue().match(Version.parse(springBootVersion)))
             .map(Map.Entry::getKey)
             .collect(Collectors.toList())
-            .stream().findFirst().orElse("NONE_SUPPORTED_SPRING_CLOUD_VERSION");
+            .stream().findFirst().orElse(NONE_SUPPORTED_VERSION);
     }
 
 }

--- a/src/test/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunnerTest.java
+++ b/src/test/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunnerTest.java
@@ -1,0 +1,59 @@
+package com.azure.spring.dev.tools.actions;
+
+import com.azure.spring.dev.tools.dependency.metadata.azure.SpringCloudAzureSupportMetadata;
+import com.azure.spring.dev.tools.dependency.metadata.maven.Version;
+import com.azure.spring.dev.tools.dependency.metadata.maven.VersionRange;
+import com.azure.spring.dev.tools.dependency.support.SpringCloudAzureSupportMetadataReader;
+import com.azure.spring.dev.tools.dependency.support.SpringInitializrMetadataReader;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class UpdateSpringCloudAzureSupportFileRunnerTest {
+
+    private final SpringInitializrMetadataReader springInitializrMetadataReader =
+        mock(SpringInitializrMetadataReader.class);
+    private final SpringCloudAzureSupportMetadataReader azureSupportMetadataReader =
+        mock(SpringCloudAzureSupportMetadataReader.class);
+    private final Map<String, VersionRange> ranges = Collections.singletonMap("2022.0.0-M1",
+        new VersionRange(Version.parse("3.0.0-M1"), true, Version.parse("3.0.0-M2"), false));
+    private final SpringCloudAzureSupportMetadata data = new SpringCloudAzureSupportMetadata();
+
+    @BeforeEach
+    void before() {
+        MockitoAnnotations.openMocks(this);
+        when(this.springInitializrMetadataReader.getCompatibleSpringBootVersions("spring-cloud")).thenReturn(ranges);
+        when(this.azureSupportMetadataReader.getAzureSupportMetadata()).thenReturn(List.of(data));
+    }
+
+    @Test
+    void testFindCompatibleSpringCloudVersion() {
+        UpdateSpringCloudAzureSupportFileRunner runner = new UpdateSpringCloudAzureSupportFileRunner(null,
+            springInitializrMetadataReader,
+            azureSupportMetadataReader, null);
+
+        String compatibleSpringCloudVersion = runner.findCompatibleSpringCloudVersion("3.0.0-M1");
+
+        Assertions.assertEquals("2022.0.0-M1", compatibleSpringCloudVersion);
+    }
+
+    @Test
+    void testNotFindCompatibleSpringCloudVersion() {
+        UpdateSpringCloudAzureSupportFileRunner runner = new UpdateSpringCloudAzureSupportFileRunner(null,
+            springInitializrMetadataReader,
+            azureSupportMetadataReader, null);
+
+        String compatibleSpringCloudVersion = runner.findCompatibleSpringCloudVersion("2.5.14");
+
+        Assertions.assertEquals(UpdateSpringCloudAzureSupportFileRunner.NONE_SUPPORTED_VERSION,
+            compatibleSpringCloudVersion);
+    }
+}

--- a/src/test/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunnerTest.java
+++ b/src/test/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunnerTest.java
@@ -25,13 +25,12 @@ class UpdateSpringCloudAzureSupportFileRunnerTest {
         mock(SpringCloudAzureSupportMetadataReader.class);
     private final Map<String, VersionRange> ranges = Collections.singletonMap("2022.0.0-M1",
         new VersionRange(Version.parse("3.0.0-M1"), true, Version.parse("3.0.0-M2"), false));
-    private final SpringCloudAzureSupportMetadata data = new SpringCloudAzureSupportMetadata();
 
     @BeforeEach
     void before() {
         MockitoAnnotations.openMocks(this);
         when(this.springInitializrMetadataReader.getCompatibleSpringBootVersions("spring-cloud")).thenReturn(ranges);
-        when(this.azureSupportMetadataReader.getAzureSupportMetadata()).thenReturn(List.of(data));
+        when(this.azureSupportMetadataReader.getAzureSupportMetadata()).thenReturn(List.of(new SpringCloudAzureSupportMetadata()));
     }
 
     @Test

--- a/src/test/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunnerTest.java
+++ b/src/test/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunnerTest.java
@@ -25,34 +25,25 @@ class UpdateSpringCloudAzureSupportFileRunnerTest {
         mock(SpringCloudAzureSupportMetadataReader.class);
     private final Map<String, VersionRange> ranges = Collections.singletonMap("2022.0.0-M1",
         new VersionRange(Version.parse("3.0.0-M1"), true, Version.parse("3.0.0-M2"), false));
+    private UpdateSpringCloudAzureSupportFileRunner runner = null;
 
     @BeforeEach
     void before() {
         MockitoAnnotations.openMocks(this);
         when(this.springInitializrMetadataReader.getCompatibleSpringBootVersions("spring-cloud")).thenReturn(ranges);
         when(this.azureSupportMetadataReader.getAzureSupportMetadata()).thenReturn(List.of(new SpringCloudAzureSupportMetadata()));
+        runner = new UpdateSpringCloudAzureSupportFileRunner(null, springInitializrMetadataReader,
+            azureSupportMetadataReader, null);
     }
 
     @Test
     void testFindCompatibleSpringCloudVersion() {
-        UpdateSpringCloudAzureSupportFileRunner runner = new UpdateSpringCloudAzureSupportFileRunner(null,
-            springInitializrMetadataReader,
-            azureSupportMetadataReader, null);
-
-        String compatibleSpringCloudVersion = runner.findCompatibleSpringCloudVersion("3.0.0-M1");
-
-        Assertions.assertEquals("2022.0.0-M1", compatibleSpringCloudVersion);
+        Assertions.assertEquals("2022.0.0-M1", runner.findCompatibleSpringCloudVersion("3.0.0-M1"));
     }
 
     @Test
     void testNotFindCompatibleSpringCloudVersion() {
-        UpdateSpringCloudAzureSupportFileRunner runner = new UpdateSpringCloudAzureSupportFileRunner(null,
-            springInitializrMetadataReader,
-            azureSupportMetadataReader, null);
-
-        String compatibleSpringCloudVersion = runner.findCompatibleSpringCloudVersion("2.5.14");
-
         Assertions.assertEquals(UpdateSpringCloudAzureSupportFileRunner.NONE_SUPPORTED_VERSION,
-            compatibleSpringCloudVersion);
+            runner.findCompatibleSpringCloudVersion("2.5.14"));
     }
 }


### PR DESCRIPTION
As title. 
Fix action [failed](https://github.com/Azure/spring-cloud-azure-tools/actions/runs/4716098675/jobs/8363509528#step:4:8924) when the new Spring Boot doesn't have a supported Spring Cloud version in [metadata](https://start.spring.io/actuator/info)
![image](https://user-images.githubusercontent.com/92105726/232357862-408630e3-f997-4acb-ad9b-40e9fe798a33.png)
