### PR TITLE
Exclude version 2.7.18 when getting metadata

### DIFF
--- a/src/main/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunner.java
+++ b/src/main/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunner.java
@@ -71,6 +71,7 @@ public class UpdateSpringCloudAzureSupportFileRunner implements CommandLineRunne
             .stream()
             .map(CONVERTER::convert)
             .filter(Objects::nonNull)
+            .filter(s -> s.getSpringBootVersion().matches("3\\.\\d\\.\\d+"))  // Only consider 3.x.x versions
             .peek(s -> s.setSpringCloudVersion(findCompatibleSpringCloudVersion(s.getSpringBootVersion())))
             .peek(s -> s.setSupportStatus(findSupportStatus(s.getSpringBootVersion())))
             .peek(s -> activeSpringBootVersions.add(s.getSpringBootVersion()))


### PR DESCRIPTION
2.7.18 can't find compatible Spring Cloud version in [actuator](https://start.spring.io/actuator/info),
but still exists in Spring Boot [metadata](https://start.spring.io/actuator/info), so filter it