### PR TITLE
Fix errors in `update-spring-dependencies.yml`

### DIFF
--- a/.github/workflows/update-spring-cloud-azure-support-file.yml
+++ b/.github/workflows/update-spring-cloud-azure-support-file.yml
@@ -35,8 +35,8 @@ jobs:
               console.log('No open PR found with the target title. Proceeding with pipeline.');
               core.setOutput('has_open_pr', 'false');
             }
-  build:
-    name: Build
+  update:
+    name: Update Support File and Create PR
     needs: check-open-pr
     if: ${{ needs.check-open-pr.outputs.has_open_pr == 'false' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/update-spring-cloud-azure-support-file.yml
+++ b/.github/workflows/update-spring-cloud-azure-support-file.yml
@@ -104,37 +104,6 @@ jobs:
           git add docs/spring/Spring-Cloud-Azure-Timeline.md
           git commit -m "${{ env.COMMIT_MESSAGE }}"
           git push "https://${{ secrets.USER }}:${{ secrets.ACCESS_TOKEN }}@github.com/${{ secrets.USER }}/azure-sdk-for-java.git"
-      - name: Close Old Pull Requests
-        if: ${{ env.NEED_UPDATE_FILE == 'true' }}
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.ACCESS_TOKEN }}
-          script: |
-            const prTitle = process.env.PR_TITLE;
-            const { data: pullRequests } = await github.rest.pulls.list({
-              owner: 'Azure',
-              repo: 'azure-sdk-for-java',
-              state: 'open'
-            });
-
-            const oldPRs = pullRequests.filter(pr => pr.title === prTitle);
-
-            for (const pr of oldPRs) {
-              console.log(`Closing PR #${pr.number} with comment`);
-              await github.rest.issues.createComment({
-                owner: 'Azure',
-                repo: 'azure-sdk-for-java',
-                issue_number: pr.number,
-                body: 'This PR has been superseded by a newer update. Closing automatically.'
-              });
-
-              await github.rest.pulls.update({
-                owner: 'Azure',
-                repo: 'azure-sdk-for-java',
-                pull_number: pr.number,
-                state: 'closed'
-              });
-            }
       - name: Create Pull Request
         id: create_pr
         if: ${{ env.NEED_UPDATE_FILE == 'true' }}

--- a/.github/workflows/update-spring-cloud-azure-support-file.yml
+++ b/.github/workflows/update-spring-cloud-azure-support-file.yml
@@ -4,9 +4,41 @@ on:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 0 * * *'
   workflow_dispatch:
+env:
+  PR_TITLE: "Update Spring Boot and Spring Cloud versions for the Spring compatibility tests"
 jobs:
+  check-open-pr:
+    name: Check Open Pull Request
+    runs-on: ubuntu-latest
+    outputs:
+      has_open_pr: ${{ steps.check.outputs.has_open_pr }}
+    steps:
+      - name: Check for Existing Open Pull Request
+        id: check
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ACCESS_TOKEN }}
+          script: |
+            const prTitle = process.env.PR_TITLE;
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner: 'Azure',
+              repo: 'azure-sdk-for-java',
+              state: 'open'
+            });
+
+            const openPRs = pullRequests.filter(pr => pr.title === prTitle);
+
+            if (openPRs.length > 0) {
+              console.log(`Found ${openPRs.length} open PR(s) with title "${prTitle}". Skipping pipeline.`);
+              core.setOutput('has_open_pr', 'true');
+            } else {
+              console.log('No open PR found with the target title. Proceeding with pipeline.');
+              core.setOutput('has_open_pr', 'false');
+            }
   build:
     name: Build
+    needs: check-open-pr
+    if: ${{ needs.check-open-pr.outputs.has_open_pr == 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -26,11 +58,9 @@ jobs:
       - name: Set Branch Name with Timestamp
         run: |
           TIMESTAMP=$(date +%Y%m%d-%H%M%S)
-          PR_TITLE="Update Spring Boot and Spring Cloud versions for the Spring compatibility tests"
           GITHUB_ACTION_URL="https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
 
           echo "BRANCH_NAME=update-spring-cloud-azure-support-file-${TIMESTAMP}" >> $GITHUB_ENV
-          echo "PR_TITLE=${PR_TITLE}" >> $GITHUB_ENV
 
           echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
           echo "${PR_TITLE}." >> $GITHUB_ENV

--- a/.github/workflows/update-spring-dependencies.yml
+++ b/.github/workflows/update-spring-dependencies.yml
@@ -118,38 +118,6 @@ jobs:
           git add -A
           git commit -m "Upgrade external dependencies to align with Spring Boot ${{ env.spring_boot_version }}"
           git push "https://${{ secrets.USER }}:${{ secrets.ACCESS_TOKEN }}@github.com/${{ secrets.USER }}/azure-sdk-for-java.git" "HEAD:${{ env.update_branch }}"
-      - name: Close Old Pull Requests
-        if: ${{ env.need_update_version == 'true' }}
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.ACCESS_TOKEN }}
-          script: |
-            const prTitlePrefix = process.env.PR_TITLE_PREFIX;
-            const { data: pullRequests } = await github.rest.pulls.list({
-              owner: 'Azure',
-              repo: 'azure-sdk-for-java',
-              state: 'open',
-              per_page: 100
-            });
-
-            const oldPRs = pullRequests.filter(pr => pr.title.startsWith(prTitlePrefix));
-
-            for (const pr of oldPRs) {
-              console.log(`Closing PR #${pr.number} with comment`);
-              await github.rest.issues.createComment({
-                owner: 'Azure',
-                repo: 'azure-sdk-for-java',
-                issue_number: pr.number,
-                body: 'This PR has been superseded by a newer update. Closing automatically.'
-              });
-
-              await github.rest.pulls.update({
-                owner: 'Azure',
-                repo: 'azure-sdk-for-java',
-                pull_number: pr.number,
-                state: 'closed'
-              });
-            }
       - name: Create Pull Request
         id: create_pr
         if: ${{ env.need_update_version == 'true' }}

--- a/.github/workflows/update-spring-dependencies.yml
+++ b/.github/workflows/update-spring-dependencies.yml
@@ -82,7 +82,40 @@ jobs:
           git add -A
           git commit -m "Upgrade external dependencies to align with Spring Boot ${{ env.spring_boot_version }}"
           git push "https://${{ secrets.USER }}:${{ secrets.ACCESS_TOKEN }}@github.com/${{ secrets.USER }}/azure-sdk-for-java.git" "HEAD:${{ env.update_branch }}"
+      - name: Close Old Pull Requests
+        if: ${{ env.need_update_version == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ACCESS_TOKEN }}
+          script: |
+            const prTitlePrefix = 'External dependencies upgrade - Spring Boot';
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner: 'Azure',
+              repo: 'azure-sdk-for-java',
+              state: 'open',
+              per_page: 100
+            });
+
+            const oldPRs = pullRequests.filter(pr => pr.title.startsWith(prTitlePrefix));
+
+            for (const pr of oldPRs) {
+              console.log(`Closing PR #${pr.number} with comment`);
+              await github.rest.issues.createComment({
+                owner: 'Azure',
+                repo: 'azure-sdk-for-java',
+                issue_number: pr.number,
+                body: 'This PR has been superseded by a newer update. Closing automatically.'
+              });
+
+              await github.rest.pulls.update({
+                owner: 'Azure',
+                repo: 'azure-sdk-for-java',
+                pull_number: pr.number,
+                state: 'closed'
+              });
+            }
       - name: Create Pull Request
+        id: create_pr
         if: ${{ env.need_update_version == 'true' }}
         uses: vsoch/pull-request-action@master
         env:
@@ -99,42 +132,19 @@ jobs:
         with:
           github-token: ${{ secrets.ACCESS_TOKEN }}
           script: |
-            const { data: pullRequests } = await github.rest.pulls.list({
-              owner: 'Azure',
-              repo: 'azure-sdk-for-java',
-              state: 'open',
-              per_page: 100
-            });
+            const prNumber = '${{ steps.create_pr.outputs.pull_request_number }}';
 
-            const prTitlePrefix = 'External dependencies upgrade - Spring Boot';
-            const matchingPRs = pullRequests
-              .filter(pr => pr.title.startsWith(prTitlePrefix))
-              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
-
-            if (matchingPRs.length <= 1) {
-              console.log('No old pull requests found to comment on.');
+            if (!prNumber) {
+              console.log('No pull request was created, nothing to comment on.');
               return;
             }
 
-            const latestPR = matchingPRs[0];
             const comment1 = `/azp run java - spring - tests`;
-            
-            console.log(`Commenting on latest PR #${latestPR.number}`);
-            await github.rest.issues.createComment({
-                owner: 'Azure',
-                repo: 'azure-sdk-for-java',
-                issue_number: latestPR.number,
-                body: comment1
-            });
-            
-            const comment2 = `A newer update PR has been created: #${latestPR.number} (${latestPR.html_url}). Please track updates there.`;
 
-            for (const pr of matchingPRs.slice(1)) {
-              console.log(`Commenting on old PR #${pr.number}`);
-              await github.rest.issues.createComment({
-                owner: 'Azure',
-                repo: 'azure-sdk-for-java',
-                issue_number: pr.number,
-                body: comment2
-              });
-            }
+            console.log(`Commenting on PR #${prNumber}`);
+            await github.rest.issues.createComment({
+              owner: 'Azure',
+              repo: 'azure-sdk-for-java',
+              issue_number: prNumber,
+              body: comment1
+            });

--- a/.github/workflows/update-spring-dependencies.yml
+++ b/.github/workflows/update-spring-dependencies.yml
@@ -10,10 +10,46 @@ on:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 0 * * *'
   workflow_dispatch:
+env:
+  PR_TITLE_PREFIX: 'External dependencies upgrade - Spring Boot'
 jobs:
-  build:
-    name: Build
+  check:
+    name: Check for Open Spring Boot Upgrade PRs
     runs-on: ubuntu-latest
+    outputs:
+      skip_pipeline: ${{ steps.check_prs.outputs.skip_pipeline }}
+    steps:
+      - name: Check for Open Spring Boot Upgrade PRs
+        id: check_prs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ACCESS_TOKEN }}
+          script: |
+            const prTitlePrefix = process.env.PR_TITLE_PREFIX;
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner: 'Azure',
+              repo: 'azure-sdk-for-java',
+              state: 'open',
+              per_page: 100
+            });
+
+            const openPRs = pullRequests.filter(pr => pr.title.startsWith(prTitlePrefix));
+
+            if (openPRs.length > 0) {
+              console.log(`Found ${openPRs.length} open PR(s) with title starting with "${prTitlePrefix}". Skipping the pipeline.`);
+              for (const pr of openPRs) {
+                console.log(`  - PR #${pr.number}: ${pr.title}`);
+              }
+              core.setOutput('skip_pipeline', 'true');
+            } else {
+              console.log('No open Spring Boot upgrade PR found. Continuing the pipeline.');
+              core.setOutput('skip_pipeline', 'false');
+            }
+  update:
+    name: Update Dependencies and Create PR
+    runs-on: ubuntu-latest
+    needs: check
+    if: ${{ needs.check.outputs.skip_pipeline != 'true' }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -36,7 +72,7 @@ jobs:
             echo "last_spring_boot_version=$(sed -n '3p' spring-versions.txt)" >> $GITHUB_ENV
             echo "last_spring_cloud_version=$(sed -n '4p' spring-versions.txt)" >> $GITHUB_ENV
             echo "pr_descriptions=$(cat pr-descriptions.txt)" >> $GITHUB_ENV
-            echo "PR_TITLE=External dependencies upgrade - Spring Boot $(sed -n '1p' spring-versions.txt) and Spring Cloud $(sed -n '2p' spring-versions.txt)" >> $GITHUB_ENV
+            echo "PR_TITLE=${PR_TITLE_PREFIX} $(sed -n '1p' spring-versions.txt) and Spring Cloud $(sed -n '2p' spring-versions.txt)" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v3
         if: ${{ env.need_update_version == 'true' }}
@@ -88,7 +124,7 @@ jobs:
         with:
           github-token: ${{ secrets.ACCESS_TOKEN }}
           script: |
-            const prTitlePrefix = 'External dependencies upgrade - Spring Boot';
+            const prTitlePrefix = process.env.PR_TITLE_PREFIX;
             const { data: pullRequests } = await github.rest.pulls.list({
               owner: 'Azure',
               repo: 'azure-sdk-for-java',

--- a/src/main/java/com/azure/spring/dev/tools/actions/UpdateSpringDependenciesRunner.java
+++ b/src/main/java/com/azure/spring/dev/tools/actions/UpdateSpringDependenciesRunner.java
@@ -47,13 +47,17 @@ public class UpdateSpringDependenciesRunner implements CommandLineRunner {
     @Override
     public void run(String... args) throws Exception {
         LOGGER.info("---------- starting {} ----------", UpdateSpringDependenciesRunner.class.getSimpleName());
-        String latestSpringBootVersion = metadataReader.getCurrentVersion(ReleaseStatus.GENERAL_AVAILABILITY);
-        String RCSpringBootVersion = metadataReader.getCurrentVersion(ReleaseStatus.PRERELEASE);
+        String latestSpringBootVersion = metadataReader.getCurrentVersion(ReleaseStatus.GENERAL_AVAILABILITY).orElse(null);
+        String RCSpringBootVersion = metadataReader.getCurrentVersion(ReleaseStatus.PRERELEASE).orElse(null);
         String azureSupportedSpringBootVersion = azureCurrentVersionReader.getCurrentSupportedSpringBootVersion();
         String azureSupportedSpringCloudVersion = azureCurrentVersionReader.getCurrentSupportedSpringCloudVersion();
         String releaseNotesContents;
         String latestSpringBootMatchedSpringCloudVersion;
-        if (!azureSupportedSpringBootVersion.equals(latestSpringBootVersion) || !azureSupportedSpringBootVersion.equals(RCSpringBootVersion)) {
+        boolean isNewGaVersionAvailable = latestSpringBootVersion != null
+            && !azureSupportedSpringBootVersion.equals(latestSpringBootVersion);
+        boolean isNewRcVersionAvailable = RCSpringBootVersion != null
+            && !azureSupportedSpringBootVersion.equals(RCSpringBootVersion);
+        if (isNewGaVersionAvailable || isNewRcVersionAvailable) {
             try (BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter("spring-versions.txt"))) {
                 latestSpringBootMatchedSpringCloudVersion = springCloudCompatibleSpringBootVersionRanges
                         .entrySet()
@@ -62,7 +66,7 @@ public class UpdateSpringDependenciesRunner implements CommandLineRunner {
                         .map(Map.Entry::getKey)
                         .findFirst()
                         .get();
-                if (!azureSupportedSpringBootVersion.equals(latestSpringBootVersion)) {
+                if (isNewGaVersionAvailable) {
                     releaseNotesContents = springBootReleaseNotesReader.getReleaseNotes(latestSpringBootVersion);
                     bufferedWriter.write(latestSpringBootVersion);
                     bufferedWriter.newLine();

--- a/src/main/java/com/azure/spring/dev/tools/dependency/support/SpringProjectMetadataReader.java
+++ b/src/main/java/com/azure/spring/dev/tools/dependency/support/SpringProjectMetadataReader.java
@@ -1,6 +1,7 @@
 package com.azure.spring.dev.tools.dependency.support;
 
 import com.azure.spring.dev.tools.dependency.configuration.DependencyProperties;
+import com.azure.spring.dev.tools.dependency.metadata.maven.Version;
 import com.azure.spring.dev.tools.dependency.metadata.maven.VersionParser;
 import com.azure.spring.dev.tools.dependency.metadata.spring.ProjectRelease;
 import com.azure.spring.dev.tools.dependency.metadata.spring.ReleaseStatus;
@@ -10,6 +11,7 @@ import org.springframework.web.client.RestTemplate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Read a Spring project's metadata from https://spring.io/project_metadata endpoint.
@@ -39,17 +41,16 @@ public class SpringProjectMetadataReader {
         return metadata.getProjectReleases();
     }
 
-    public String getCurrentVersion(ReleaseStatus releaseStatus) {
+    public Optional<String> getCurrentVersion(ReleaseStatus releaseStatus) {
         return getProjectReleases()
             .stream()
             .filter(p -> p.getReleaseStatus().equals(releaseStatus))
             .filter(p -> p.getVersion().startsWith("4"))
             .map(ProjectRelease::getVersion)
             .map(VersionParser.DEFAULT::parse)
-            .sorted(Comparator.reverseOrder())
             .filter(Objects::nonNull)
+            .sorted(Comparator.reverseOrder())
             .findFirst()
-            .get()
-            .toString();
+            .map(Version::toString);
     }
 }


### PR DESCRIPTION
## Summary

 - Return Optional from getCurrentVersion instead of calling Optional.get() on a possibly-empty stream, and guard the update logic with availability flags so an absent prerelease version no longer crashes the runner.\
 - Fix error about failed to adding comments in related PRs in GitHub action.

## Related Pipelines

 - Before current PR: https://github.com/Azure/spring-cloud-azure-tools/actions/runs/27517022133/job/81327427583#step:4:6221
 - After current PR: https://github.com/Azure/spring-cloud-azure-tools/actions/runs/27519363147/job/81334118061