### PR TITLE
Only update timeline when Spring Boot 4.x changes

### DIFF
--- a/.github/workflows/update-spring-cloud-azure-support-file.yml
+++ b/.github/workflows/update-spring-cloud-azure-support-file.yml
@@ -90,8 +90,8 @@ jobs:
           SUPPORT_FILE=sdk/spring/pipeline/spring-cloud-azure-supported-spring.json
 
           # Only add a new timeline item when Spring Boot 4.x entries are updated.
-          OLD_4X=$(git show HEAD:${SUPPORT_FILE} | jq -S '[.[] | select(."spring-boot-version" | startswith("4."))]')
-          NEW_4X=$(jq -S '[.[] | select(."spring-boot-version" | startswith("4."))]' "${SUPPORT_FILE}")
+          OLD_4X=$(git show "HEAD:${SUPPORT_FILE}" | jq -Sc '[.[] | select(."spring-boot-version" | startswith("4."))] | sort_by(."spring-boot-version", ."spring-cloud-version", .supportStatus, .current)')
+          NEW_4X=$(jq -Sc '[.[] | select(."spring-boot-version" | startswith("4."))] | sort_by(."spring-boot-version", ."spring-cloud-version", .supportStatus, .current)' "${SUPPORT_FILE}")
 
           if [[ "${OLD_4X}" == "${NEW_4X}" ]]; then
             echo "No Spring Boot 4.x changes detected, skip timeline update."

--- a/.github/workflows/update-spring-cloud-azure-support-file.yml
+++ b/.github/workflows/update-spring-cloud-azure-support-file.yml
@@ -87,16 +87,30 @@ jobs:
           cd azure-sdk-for-java
           TODAY=$(date +%Y-%m-%d)
           TIMELINE_FILE=docs/spring/Spring-Cloud-Azure-Timeline.md
-          # The compatibility tests only run the SUPPORTED versions whose Spring Boot
-          # major version matches the current one (see compatibility_update_supported_version_matrix_json.py),
-          # so only list those here.
+          SUPPORT_FILE=sdk/spring/pipeline/spring-cloud-azure-supported-spring.json
+
+          # Only add a new timeline item when Spring Boot 4.x entries are updated.
+          OLD_4X=$(git show HEAD:${SUPPORT_FILE} | jq -S '[.[] | select(."spring-boot-version" | startswith("4."))]')
+          NEW_4X=$(jq -S '[.[] | select(."spring-boot-version" | startswith("4."))]' "${SUPPORT_FILE}")
+
+          if [[ "${OLD_4X}" == "${NEW_4X}" ]]; then
+            echo "No Spring Boot 4.x changes detected, skip timeline update."
+            exit 0
+          fi
+
+          # List the current SUPPORTED Spring Boot 4.x compatibility test matrix.
           SUPPORTED_LINES=$(jq -r '
-            (map(select(.current == true)) | .[0]["spring-boot-version"] | split(".")[0]) as $major
-            | .[]
+            .[]
             | select(.supportStatus == "SUPPORTED")
-            | select(.["spring-boot-version"] | startswith($major + "."))
+            | select(.["spring-boot-version"] | startswith("4."))
             | "   - spring-boot-dependencies:\(.["spring-boot-version"]) and spring-cloud-dependencies:\(.["spring-cloud-version"])."
-          ' sdk/spring/pipeline/spring-cloud-azure-supported-spring.json)
+          ' "${SUPPORT_FILE}")
+
+          if [[ -z "${SUPPORTED_LINES}" ]]; then
+            echo "No supported Spring Boot 4.x entries found, skip timeline update."
+            exit 0
+          fi
+
           NEW_ENTRY=$(printf ' - **%s**: In "java - spring - compatibility - tests" pipeline, run unit tests:\n%s' "$TODAY" "$SUPPORTED_LINES")
           awk -v entry="$NEW_ENTRY" '
             { print }

--- a/.github/workflows/update-spring-cloud-azure-support-file.yml
+++ b/.github/workflows/update-spring-cloud-azure-support-file.yml
@@ -90,8 +90,8 @@ jobs:
           SUPPORT_FILE=sdk/spring/pipeline/spring-cloud-azure-supported-spring.json
 
           # Only add a new timeline item when Spring Boot 4.x entries are updated.
-          OLD_4X=$(git show "HEAD:${SUPPORT_FILE}" | jq -Sc '[.[] | select(."spring-boot-version" | startswith("4."))] | sort_by(."spring-boot-version", ."spring-cloud-version", .supportStatus, .current)')
-          NEW_4X=$(jq -Sc '[.[] | select(."spring-boot-version" | startswith("4."))] | sort_by(."spring-boot-version", ."spring-cloud-version", .supportStatus, .current)' "${SUPPORT_FILE}")
+          OLD_4X=$(git show "HEAD:${SUPPORT_FILE}" | jq -Sc '[.[] | select(."spring-boot-version" | startswith("4."))] | sort_by([."spring-boot-version", ."spring-cloud-version", .supportStatus, .current])')
+          NEW_4X=$(jq -Sc '[.[] | select(."spring-boot-version" | startswith("4."))] | sort_by([."spring-boot-version", ."spring-cloud-version", .supportStatus, .current])' "${SUPPORT_FILE}")
 
           if [[ "${OLD_4X}" == "${NEW_4X}" ]]; then
             echo "No Spring Boot 4.x changes detected, skip timeline update."


### PR DESCRIPTION
## Summary

- update workflow timeline logic to append a new timeline item only when Spring Boot 4.x entries change
- skip timeline update when only Spring Boot 3.x entries change
- keep timeline content limited to supported Spring Boot 4.x matrix entries



## Why

- avoid noisy timeline updates for 3.x-only changes
- align timeline updates with the intended 4.x update signal



## Validation

- Created PR before current PR: https://github.com/Azure/azure-sdk-for-java/pull/49640
- Created PR after current PR: https://github.com/Azure/azure-sdk-for-java/pull/49642.
