### PR TITLE
Use GitHub App token in update workflows

### DIFF
--- a/.github/actions/github-app-token/action.yml
+++ b/.github/actions/github-app-token/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: Installation owner
     required: false
     default: Azure
+  repositories:
+    description: Comma or newline separated list of repository names for token scoping
+    required: false
+    default: azure-sdk-for-java
 outputs:
   token:
     description: GitHub App installation token
@@ -25,3 +29,4 @@ runs:
         app-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.private-key }}
         owner: ${{ inputs.owner }}
+        repositories: ${{ inputs.repositories }}

--- a/.github/actions/github-app-token/action.yml
+++ b/.github/actions/github-app-token/action.yml
@@ -1,0 +1,27 @@
+name: GitHub App Token
+description: Generate a GitHub App installation token for workflows.
+inputs:
+  app-id:
+    description: GitHub App ID
+    required: true
+  private-key:
+    description: GitHub App private key
+    required: true
+  owner:
+    description: Installation owner
+    required: false
+    default: Azure
+outputs:
+  token:
+    description: GitHub App installation token
+    value: ${{ steps.app-token.outputs.token }}
+runs:
+  using: composite
+  steps:
+    - name: Generate GitHub App Token
+      id: app-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: ${{ inputs.owner }}

--- a/.github/actions/github-app-token/action.yml
+++ b/.github/actions/github-app-token/action.yml
@@ -26,7 +26,7 @@ runs:
       id: app-token
       uses: actions/create-github-app-token@v3.2.0
       with:
-        app-id: ${{ inputs.app-id }}
-        private-key: ${{ inputs.private-key }}
+        app-id: ${{ inputs['app-id'] }}
+        private-key: ${{ inputs['private-key'] }}
         owner: ${{ inputs.owner }}
         repositories: ${{ inputs.repositories }}

--- a/.github/actions/github-app-token/action.yml
+++ b/.github/actions/github-app-token/action.yml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Generate GitHub App Token
       id: app-token
-      uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
+      uses: actions/create-github-app-token@v3.2.0
       with:
         app-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.private-key }}

--- a/.github/actions/github-app-token/action.yml
+++ b/.github/actions/github-app-token/action.yml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Generate GitHub App Token
       id: app-token
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
       with:
         app-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.private-key }}

--- a/.github/workflows/test-spring-boot-rc-version.yml
+++ b/.github/workflows/test-spring-boot-rc-version.yml
@@ -7,8 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          repository: 'Azure/spring-cloud-azure-tools'
       - name: Generate GitHub App Token
         id: app-token
         uses: ./.github/actions/github-app-token

--- a/.github/workflows/test-spring-boot-rc-version.yml
+++ b/.github/workflows/test-spring-boot-rc-version.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          repositories: azure-sdk-for-java
       - name: Generate Version File
         run: |
           mvn compile
@@ -49,6 +50,7 @@ jobs:
           ref: main
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1
+          persist-credentials: false
       - name: Generate spring_boot_managed_external_dependencies.txt
         if: ${{ env.need_update_version == 'true' }}
         run: |

--- a/.github/workflows/test-spring-boot-rc-version.yml
+++ b/.github/workflows/test-spring-boot-rc-version.yml
@@ -6,9 +6,15 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: 'Azure/spring-cloud-azure-tools'
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: ./.github/actions/github-app-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: Generate Version File
         run: |
           mvn compile
@@ -35,13 +41,13 @@ jobs:
           else
             echo "No RC version,cancel update!"
           fi
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ env.need_update_version == 'true' }}
         with:
           repository: 'Azure/azure-sdk-for-java'
           path: 'azure-sdk-for-java'
           ref: main
-          token: ${{ secrets.ACCESS_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1
       - name: Generate spring_boot_managed_external_dependencies.txt
         if: ${{ env.need_update_version == 'true' }}
@@ -81,15 +87,15 @@ jobs:
           cp -f ../spring-cloud-azure-supported-spring.json sdk/spring/pipeline
           git add sdk/spring/pipeline/spring-cloud-azure-supported-spring.json
           git commit -m "Upgrade spring-cloud-azure-supported-spring"
-          git push "https://${{ secrets.USER }}:${{ secrets.ACCESS_TOKEN }}@github.com/${{ secrets.USER }}/azure-sdk-for-java.git" "HEAD:${{ env.update_branch }}"
+          git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/Azure/azure-sdk-for-java.git" "HEAD:${{ env.update_branch }}"
       - name: Create Pull Request
         if: ${{ env.need_update_version == 'true' }}
         uses: vsoch/pull-request-action@master
         env:
-          PULL_REQUEST_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          PULL_REQUEST_TOKEN: ${{ steps.app-token.outputs.token }}
           PULL_REQUEST_REPOSITORY: Azure/azure-sdk-for-java
           PULL_REQUEST_TITLE: "${{ env.PR_TITLE }}"
-          PULL_REQUEST_FROM_BRANCH: "${{ secrets.USER }}:${{ env.update_branch }}"
+          PULL_REQUEST_FROM_BRANCH: "${{ env.update_branch }}"
           PULL_REQUEST_BRANCH: "main"
           PULL_REQUEST_BODY: "Test Spring Boot RC version [${{ env.spring_boot_version }}](https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/${{ env.spring_boot_version }}/spring-boot-dependencies-${{ env.spring_boot_version }}.pom) and Spring Cloud version [${{ env.spring_cloud_version }}](https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dependencies/${{ env.spring_cloud_version }}/spring-cloud-dependencies-${{ env.spring_cloud_version }}.pom).\n${{ env.pr_descriptions }}\n\nThis PR is created by GitHub Actions: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
           PULL_REQUEST_DRAFT: true
@@ -97,7 +103,7 @@ jobs:
         if: ${{ env.need_update_version == 'true' }}
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.ACCESS_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { data: pullRequests } = await github.rest.pulls.list({
               owner: 'Azure',

--- a/.github/workflows/test-spring-boot-rc-version.yml
+++ b/.github/workflows/test-spring-boot-rc-version.yml
@@ -90,7 +90,7 @@ jobs:
           git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/Azure/azure-sdk-for-java.git" "HEAD:${{ env.update_branch }}"
       - name: Create Pull Request
         if: ${{ env.need_update_version == 'true' }}
-        uses: vsoch/pull-request-action@77b3eea5c721545c56f775e1ed4ff9c9c1386148
+        uses: vsoch/pull-request-action@1.1.1
         env:
           PULL_REQUEST_TOKEN: ${{ steps.app-token.outputs.token }}
           PULL_REQUEST_REPOSITORY: Azure/azure-sdk-for-java

--- a/.github/workflows/test-spring-boot-rc-version.yml
+++ b/.github/workflows/test-spring-boot-rc-version.yml
@@ -90,7 +90,7 @@ jobs:
           git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/Azure/azure-sdk-for-java.git" "HEAD:${{ env.update_branch }}"
       - name: Create Pull Request
         if: ${{ env.need_update_version == 'true' }}
-        uses: vsoch/pull-request-action@master
+        uses: vsoch/pull-request-action@77b3eea5c721545c56f775e1ed4ff9c9c1386148
         env:
           PULL_REQUEST_TOKEN: ${{ steps.app-token.outputs.token }}
           PULL_REQUEST_REPOSITORY: Azure/azure-sdk-for-java

--- a/.github/workflows/update-spring-cloud-azure-support-file.yml
+++ b/.github/workflows/update-spring-cloud-azure-support-file.yml
@@ -13,11 +13,20 @@ jobs:
     outputs:
       has_open_pr: ${{ steps.check.outputs.has_open_pr }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'Azure/spring-cloud-azure-tools'
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: ./.github/actions/github-app-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: Check for Existing Open Pull Request
         id: check
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.ACCESS_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const prTitle = process.env.PR_TITLE;
             const { data: pullRequests } = await github.rest.pulls.list({
@@ -41,19 +50,25 @@ jobs:
     if: ${{ needs.check-open-pr.outputs.has_open_pr == 'false' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: 'Azure/spring-cloud-azure-tools'
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: ./.github/actions/github-app-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: Generate Spring Cloud Azure Support File
         run: |
           mvn compile
           mvn exec:java -P github-actions -ntp -Dupdate-spring-cloud-azure-support-file=true
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: 'Azure/azure-sdk-for-java'
           path: 'azure-sdk-for-java'
           ref: main
-          token: ${{ secrets.ACCESS_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
       - name: Set Branch Name with Timestamp
         run: |
@@ -126,23 +141,23 @@ jobs:
           git add sdk/spring/pipeline/spring-cloud-azure-supported-spring.json
           git add docs/spring/Spring-Cloud-Azure-Timeline.md
           git commit -m "${{ env.COMMIT_MESSAGE }}"
-          git push "https://${{ secrets.USER }}:${{ secrets.ACCESS_TOKEN }}@github.com/${{ secrets.USER }}/azure-sdk-for-java.git"
+          git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/Azure/azure-sdk-for-java.git" "${{ env.BRANCH_NAME }}"
       - name: Create Pull Request
         id: create_pr
         if: ${{ env.NEED_UPDATE_FILE == 'true' }}
         uses: vsoch/pull-request-action@master
         env:
-          PULL_REQUEST_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          PULL_REQUEST_TOKEN: ${{ steps.app-token.outputs.token }}
           PULL_REQUEST_REPOSITORY: Azure/azure-sdk-for-java
           PULL_REQUEST_TITLE: "${{ env.PR_TITLE }}"
-          PULL_REQUEST_FROM_BRANCH: "${{ secrets.USER }}:${{ env.BRANCH_NAME }}"
+          PULL_REQUEST_FROM_BRANCH: "${{ env.BRANCH_NAME }}"
           PULL_REQUEST_BRANCH: "main"
           PULL_REQUEST_BODY: "${{ env.PULL_REQUEST_BODY }}"
       - name: Comment on Pull Requests
         if: ${{ env.NEED_UPDATE_FILE == 'true' }}
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.ACCESS_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const prNumber = '${{ steps.create_pr.outputs.pull_request_number }}';
 

--- a/.github/workflows/update-spring-cloud-azure-support-file.yml
+++ b/.github/workflows/update-spring-cloud-azure-support-file.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Create Pull Request
         id: create_pr
         if: ${{ env.NEED_UPDATE_FILE == 'true' }}
-        uses: vsoch/pull-request-action@77b3eea5c721545c56f775e1ed4ff9c9c1386148
+        uses: vsoch/pull-request-action@1.1.1
         env:
           PULL_REQUEST_TOKEN: ${{ steps.app-token.outputs.token }}
           PULL_REQUEST_REPOSITORY: Azure/azure-sdk-for-java

--- a/.github/workflows/update-spring-cloud-azure-support-file.yml
+++ b/.github/workflows/update-spring-cloud-azure-support-file.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          repositories: azure-sdk-for-java
       - name: Check for Existing Open Pull Request
         id: check
         uses: actions/github-script@v7
@@ -59,6 +60,7 @@ jobs:
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          repositories: azure-sdk-for-java
       - name: Generate Spring Cloud Azure Support File
         run: |
           mvn compile
@@ -70,6 +72,7 @@ jobs:
           ref: main
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Set Branch Name with Timestamp
         run: |
           TIMESTAMP=$(date +%Y%m%d-%H%M%S)

--- a/.github/workflows/update-spring-cloud-azure-support-file.yml
+++ b/.github/workflows/update-spring-cloud-azure-support-file.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Create Pull Request
         id: create_pr
         if: ${{ env.NEED_UPDATE_FILE == 'true' }}
-        uses: vsoch/pull-request-action@master
+        uses: vsoch/pull-request-action@77b3eea5c721545c56f775e1ed4ff9c9c1386148
         env:
           PULL_REQUEST_TOKEN: ${{ steps.app-token.outputs.token }}
           PULL_REQUEST_REPOSITORY: Azure/azure-sdk-for-java

--- a/.github/workflows/update-spring-cloud-azure-support-file.yml
+++ b/.github/workflows/update-spring-cloud-azure-support-file.yml
@@ -14,8 +14,6 @@ jobs:
       has_open_pr: ${{ steps.check.outputs.has_open_pr }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          repository: 'Azure/spring-cloud-azure-tools'
       - name: Generate GitHub App Token
         id: app-token
         uses: ./.github/actions/github-app-token
@@ -52,8 +50,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          repository: 'Azure/spring-cloud-azure-tools'
       - name: Generate GitHub App Token
         id: app-token
         uses: ./.github/actions/github-app-token

--- a/.github/workflows/update-spring-dependencies.yml
+++ b/.github/workflows/update-spring-dependencies.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Create Pull Request
         id: create_pr
         if: ${{ env.need_update_version == 'true' }}
-        uses: vsoch/pull-request-action@master
+        uses: vsoch/pull-request-action@77b3eea5c721545c56f775e1ed4ff9c9c1386148
         env:
           PULL_REQUEST_TOKEN: ${{ steps.app-token.outputs.token }}
           PULL_REQUEST_REPOSITORY: Azure/azure-sdk-for-java

--- a/.github/workflows/update-spring-dependencies.yml
+++ b/.github/workflows/update-spring-dependencies.yml
@@ -20,8 +20,6 @@ jobs:
       skip_pipeline: ${{ steps.check_prs.outputs.skip_pipeline }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          repository: 'Azure/spring-cloud-azure-tools'
       - name: Generate GitHub App Token
         id: app-token
         uses: ./.github/actions/github-app-token
@@ -62,8 +60,6 @@ jobs:
     if: ${{ needs.check.outputs.skip_pipeline != 'true' }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          repository: 'Azure/spring-cloud-azure-tools'
       - name: Generate GitHub App Token
         id: app-token
         uses: ./.github/actions/github-app-token

--- a/.github/workflows/update-spring-dependencies.yml
+++ b/.github/workflows/update-spring-dependencies.yml
@@ -19,11 +19,20 @@ jobs:
     outputs:
       skip_pipeline: ${{ steps.check_prs.outputs.skip_pipeline }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'Azure/spring-cloud-azure-tools'
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: ./.github/actions/github-app-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: Check for Open Spring Boot Upgrade PRs
         id: check_prs
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.ACCESS_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const prTitlePrefix = process.env.PR_TITLE_PREFIX;
             const { data: pullRequests } = await github.rest.pulls.list({
@@ -51,9 +60,15 @@ jobs:
     needs: check
     if: ${{ needs.check.outputs.skip_pipeline != 'true' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: 'Azure/spring-cloud-azure-tools'
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: ./.github/actions/github-app-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: Generate Version File
         run: |
           mvn compile
@@ -74,13 +89,13 @@ jobs:
             echo "pr_descriptions=$(cat pr-descriptions.txt)" >> $GITHUB_ENV
             echo "PR_TITLE=${PR_TITLE_PREFIX} $(sed -n '1p' spring-versions.txt) and Spring Cloud $(sed -n '2p' spring-versions.txt)" >> $GITHUB_ENV
           fi
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ env.need_update_version == 'true' }}
         with:
           repository: 'Azure/azure-sdk-for-java'
           path: 'azure-sdk-for-java'
           ref: main
-          token: ${{ secrets.ACCESS_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1
       - name: Generate spring_boot_managed_external_dependencies.txt
         if: ${{ env.need_update_version == 'true' }}
@@ -117,16 +132,16 @@ jobs:
           git rm ./sdk/spring/scripts/spring_boot_${{ env.last_spring_boot_version }}_managed_external_dependencies.txt
           git add -A
           git commit -m "Upgrade external dependencies to align with Spring Boot ${{ env.spring_boot_version }}"
-          git push "https://${{ secrets.USER }}:${{ secrets.ACCESS_TOKEN }}@github.com/${{ secrets.USER }}/azure-sdk-for-java.git" "HEAD:${{ env.update_branch }}"
+          git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/Azure/azure-sdk-for-java.git" "HEAD:${{ env.update_branch }}"
       - name: Create Pull Request
         id: create_pr
         if: ${{ env.need_update_version == 'true' }}
         uses: vsoch/pull-request-action@master
         env:
-          PULL_REQUEST_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          PULL_REQUEST_TOKEN: ${{ steps.app-token.outputs.token }}
           PULL_REQUEST_REPOSITORY: Azure/azure-sdk-for-java
           PULL_REQUEST_TITLE: "${{ env.PR_TITLE }}"
-          PULL_REQUEST_FROM_BRANCH: "${{ secrets.USER }}:${{ env.update_branch }}"
+          PULL_REQUEST_FROM_BRANCH: "${{ env.update_branch }}"
           PULL_REQUEST_BRANCH: "main"
           PULL_REQUEST_BODY: "Updates external dependencies to align with Spring Boot version [${{ env.spring_boot_version }}](https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/${{ env.spring_boot_version }}/spring-boot-dependencies-${{ env.spring_boot_version }}.pom) from [${{ env.last_spring_boot_version }}](https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/${{ env.last_spring_boot_version }}/spring-boot-dependencies-${{ env.last_spring_boot_version }}.pom) and Spring Cloud version [${{ env.spring_cloud_version }}](https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dependencies/${{ env.spring_cloud_version }}/spring-cloud-dependencies-${{ env.spring_cloud_version }}.pom) from [${{ env.last_spring_cloud_version }}](https://repo1.maven.org/maven2/org/springframework/cloud/spring-cloud-dependencies/${{ env.last_spring_cloud_version }}/spring-cloud-dependencies-${{ env.last_spring_cloud_version }}.pom).\n${{ env.pr_descriptions }}\n\nThis PR is created by GitHub Actions: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
           PULL_REQUEST_DRAFT: false
@@ -134,7 +149,7 @@ jobs:
         if: ${{ env.need_update_version == 'true' }}
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.ACCESS_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const prNumber = '${{ steps.create_pr.outputs.pull_request_number }}';
 

--- a/.github/workflows/update-spring-dependencies.yml
+++ b/.github/workflows/update-spring-dependencies.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          repositories: azure-sdk-for-java
       - name: Check for Open Spring Boot Upgrade PRs
         id: check_prs
         uses: actions/github-script@v7
@@ -69,6 +70,7 @@ jobs:
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          repositories: azure-sdk-for-java
       - name: Generate Version File
         run: |
           mvn compile
@@ -97,6 +99,7 @@ jobs:
           ref: main
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1
+          persist-credentials: false
       - name: Generate spring_boot_managed_external_dependencies.txt
         if: ${{ env.need_update_version == 'true' }}
         run: |

--- a/.github/workflows/update-spring-dependencies.yml
+++ b/.github/workflows/update-spring-dependencies.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Create Pull Request
         id: create_pr
         if: ${{ env.need_update_version == 'true' }}
-        uses: vsoch/pull-request-action@77b3eea5c721545c56f775e1ed4ff9c9c1386148
+        uses: vsoch/pull-request-action@1.1.1
         env:
           PULL_REQUEST_TOKEN: ${{ steps.app-token.outputs.token }}
           PULL_REQUEST_REPOSITORY: Azure/azure-sdk-for-java


### PR DESCRIPTION
## What
- Replace `ACCESS_TOKEN` usage with GitHub App installation token in update workflows.
- Add a reusable local action for token generation at `.github/actions/github-app-token/action.yml`.
- Scope GitHub App tokens to `azure-sdk-for-java` via a `repositories` input to enforce least privilege.
- Set `persist-credentials: false` on authenticated `actions/checkout` steps that use installation tokens.
- Update PR/push flow to use same-repo branch format with GitHub App token.
- Upgrade `actions/checkout` from `v3` to `v4` in the updated workflows.
- Pin third-party actions to fixed release tags:
  - `actions/create-github-app-token@v3.2.0`
  - `vsoch/pull-request-action@1.1.1`
- Ensure same-repo checkout uses the workflow triggering ref (avoid default-branch drift).
- Fix hyphenated composite action input references using bracket syntax.

## Why
- `The 'Microsoft Open Source' enterprise forbids access via a personal access tokens (classic) if the token's lifetime is greater than 8 days.`. See: https://github.com/Azure/spring-cloud-azure-tools/actions/runs/28485381020/job/84430597949
- Remove PAT dependency and standardize on GitHub App auth.
- Reduce token blast radius and credential persistence risk in workflow runners.
- Improve reproducibility and supply-chain hygiene by avoiding floating refs.
- Keep local action execution aligned with the exact workflow ref.

## Updated files
- `.github/actions/github-app-token/action.yml`
- `.github/workflows/update-spring-cloud-azure-support-file.yml`
- `.github/workflows/test-spring-boot-rc-version.yml`
- `.github/workflows/update-spring-dependencies.yml`