### PR TITLE
Keep last known Spring Cloud version for supported Spring Boot generations

### DIFF
--- a/.github/workflows/update-spring-cloud-azure-support-file.yml
+++ b/.github/workflows/update-spring-cloud-azure-support-file.yml
@@ -126,6 +126,7 @@ jobs:
           git add sdk/spring/pipeline/spring-cloud-azure-supported-spring.json
           git add docs/spring/Spring-Cloud-Azure-Timeline.md
           git commit -m "${{ env.COMMIT_MESSAGE }}"
+          # secrets.USER is the GitHub username of the user who created the Personal Access Token (PAT) stored in secrets.ACCESS_TOKEN.
           git push "https://${{ secrets.USER }}:${{ secrets.ACCESS_TOKEN }}@github.com/${{ secrets.USER }}/azure-sdk-for-java.git"
       - name: Create Pull Request
         id: create_pr

--- a/src/main/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunner.java
+++ b/src/main/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunner.java
@@ -22,10 +22,12 @@ import org.springframework.stereotype.Component;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -145,13 +147,51 @@ public class UpdateSpringCloudAzureSupportFileRunner implements CommandLineRunne
         if (supportMetadata != null && supportMetadata.getSupportStatus() == SupportStatus.END_OF_LIFE) {
             return supportMetadata.getSpringCloudVersion();
         }
-        return this.springCloudCompatibleSpringBootVersionRanges
+        String resolvedSpringCloudVersion = this.springCloudCompatibleSpringBootVersionRanges
             .entrySet()
             .stream()
             .filter(entry -> entry.getValue().match(Version.parse(springBootVersion)))
             .map(Map.Entry::getKey)
-            .collect(Collectors.toList())
-            .stream().findFirst().orElse(NONE_SUPPORTED_VERSION);
+            .findFirst()
+            .orElse(NONE_SUPPORTED_VERSION);
+        if (!NONE_SUPPORTED_VERSION.equals(resolvedSpringCloudVersion)) {
+            return resolvedSpringCloudVersion;
+        }
+        // start.spring.io dropped this still-supported Spring Boot generation: keep the last known Spring Cloud
+        // version instead of regressing to NONE - first for the exact Spring Boot version, ...
+        if (isUsableSpringCloudVersion(supportMetadata)) {
+            return supportMetadata.getSpringCloudVersion();
+        }
+        // ... otherwise the highest known version from the same MAJOR.MINOR line (e.g. a brand-new patch).
+        return findSpringCloudVersionFromSameMinorLine(springBootVersion).orElse(NONE_SUPPORTED_VERSION);
+    }
+
+    private static boolean isUsableSpringCloudVersion(SpringCloudAzureSupportMetadata metadata) {
+        return metadata != null
+            && metadata.getSpringCloudVersion() != null
+            && !NONE_SUPPORTED_VERSION.equals(metadata.getSpringCloudVersion());
+    }
+
+    private Optional<String> findSpringCloudVersionFromSameMinorLine(String springBootVersion) {
+        Version targetVersion = Version.safeParse(springBootVersion);
+        if (targetVersion == null || targetVersion.getMajor() == null || targetVersion.getMinor() == null) {
+            return Optional.empty();
+        }
+        return this.azureSupportMetadataMap
+            .values()
+            .stream()
+            .filter(UpdateSpringCloudAzureSupportFileRunner::isUsableSpringCloudVersion)
+            .filter(metadata -> isSameMinorLine(targetVersion, metadata.getSpringBootVersion()))
+            .max(Comparator.comparing(
+                (SpringCloudAzureSupportMetadata metadata) -> Version.parse(metadata.getSpringBootVersion())))
+            .map(SpringCloudAzureSupportMetadata::getSpringCloudVersion);
+    }
+
+    private static boolean isSameMinorLine(Version targetVersion, String springBootVersion) {
+        Version version = springBootVersion == null ? null : Version.safeParse(springBootVersion);
+        return version != null
+            && targetVersion.getMajor().equals(version.getMajor())
+            && targetVersion.getMinor().equals(version.getMinor());
     }
 
     /**

--- a/src/test/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunnerTest.java
+++ b/src/test/java/com/azure/spring/dev/tools/actions/UpdateSpringCloudAzureSupportFileRunnerTest.java
@@ -51,6 +51,57 @@ class UpdateSpringCloudAzureSupportFileRunnerTest {
     }
 
     @Test
+    void testRetainsLastKnownSpringCloudVersionWhenInitializrDropsGeneration() {
+        // Initializr no longer matches the still-SUPPORTED 3.5.16, so it keeps its recorded Spring Cloud version.
+        UpdateSpringCloudAzureSupportFileRunner runnerUnderTest = createRunner(springCloudRangesFor4x(),
+            List.of(createSupportMetadata("3.5.16", "2025.0.3", SupportStatus.SUPPORTED)));
+
+        Assertions.assertEquals("2025.0.3", runnerUnderTest.findCompatibleSpringCloudVersion("3.5.16"));
+    }
+
+    @Test
+    void testPrefersInitializrMatchOverLastKnownSpringCloudVersion() {
+        // An Initializr match still wins over the recorded value (auto-upgrade preserved, no regression).
+        Map<String, VersionRange> ranges = Collections.singletonMap("2025.0.4",
+            new VersionRange(Version.parse("3.5.0"), true, Version.parse("3.6.0-M1"), false));
+        UpdateSpringCloudAzureSupportFileRunner runnerUnderTest = createRunner(ranges,
+            List.of(createSupportMetadata("3.5.16", "2025.0.3", SupportStatus.SUPPORTED)));
+
+        Assertions.assertEquals("2025.0.4", runnerUnderTest.findCompatibleSpringCloudVersion("3.5.16"));
+    }
+
+    @Test
+    void testFallsBackToHighestSpringCloudVersionFromSameMinorLine() {
+        // A new patch (3.5.17) with no entry and no Initializr match reuses the highest known 3.5.x value.
+        UpdateSpringCloudAzureSupportFileRunner runnerUnderTest = createRunner(springCloudRangesFor4x(),
+            List.of(
+                createSupportMetadata("3.5.16", "2025.0.3", SupportStatus.SUPPORTED),
+                createSupportMetadata("3.5.15", "2025.0.3", SupportStatus.END_OF_LIFE),
+                createSupportMetadata("3.5.14", "2025.0.2", SupportStatus.END_OF_LIFE)));
+
+        Assertions.assertEquals("2025.0.3", runnerUnderTest.findCompatibleSpringCloudVersion("3.5.17"));
+    }
+
+    @Test
+    void testReturnsNoneWhenNoSameMinorLineIsKnown() {
+        // No Initializr match and no recorded 3.5.x entry to fall back to, so the result stays NONE.
+        UpdateSpringCloudAzureSupportFileRunner runnerUnderTest = createRunner(springCloudRangesFor4x(),
+            List.of(createSupportMetadata("4.0.7", "2025.1.2", SupportStatus.SUPPORTED)));
+
+        Assertions.assertEquals(UpdateSpringCloudAzureSupportFileRunner.NONE_SUPPORTED_VERSION,
+            runnerUnderTest.findCompatibleSpringCloudVersion("3.5.99"));
+    }
+
+    @Test
+    void testEndOfLifeVersionKeepsRecordedSpringCloudVersion() {
+        // END_OF_LIFE versions always keep their recorded Spring Cloud version, regardless of Initializr.
+        UpdateSpringCloudAzureSupportFileRunner runnerUnderTest = createRunner(springCloudRangesFor4x(),
+            List.of(createSupportMetadata("3.4.0", "2023.0.5", SupportStatus.END_OF_LIFE)));
+
+        Assertions.assertEquals("2023.0.5", runnerUnderTest.findCompatibleSpringCloudVersion("3.4.0"));
+    }
+
+    @Test
     void testSetNewStatusWithSupport() {
         SpringCloudAzureSupportMetadata metadata = new SpringCloudAzureSupportMetadata();
         metadata.setReleaseStatus(ReleaseStatus.GENERAL_AVAILABILITY);
@@ -115,5 +166,30 @@ class UpdateSpringCloudAzureSupportFileRunnerTest {
 
         metadata.setSpringBootVersion("3.5.0-M1");
         Assertions.assertTrue(runnerWithRc.isSnapshotOrMilestoneOrRC(metadata));
+    }
+
+    private UpdateSpringCloudAzureSupportFileRunner createRunner(Map<String, VersionRange> springCloudRanges,
+                                                                 List<SpringCloudAzureSupportMetadata> supportMetadataList) {
+        when(this.springInitializrMetadataReader.getCompatibleSpringBootVersions("spring-cloud"))
+            .thenReturn(springCloudRanges);
+        when(this.azureSupportMetadataReader.getAzureSupportMetadata()).thenReturn(supportMetadataList);
+        return new UpdateSpringCloudAzureSupportFileRunner(null, springInitializrMetadataReader,
+            azureSupportMetadataReader, null, false);
+    }
+
+    private static SpringCloudAzureSupportMetadata createSupportMetadata(String springBootVersion,
+                                                                         String springCloudVersion,
+                                                                         SupportStatus supportStatus) {
+        SpringCloudAzureSupportMetadata metadata = new SpringCloudAzureSupportMetadata();
+        metadata.setSpringBootVersion(springBootVersion);
+        metadata.setSpringCloudVersion(springCloudVersion);
+        metadata.setSupportStatus(supportStatus);
+        return metadata;
+    }
+
+    private static Map<String, VersionRange> springCloudRangesFor4x() {
+        // Mirrors the current start.spring.io payload, which only exposes the Spring Boot 4.x compatible train.
+        return Collections.singletonMap("2025.1.2",
+            new VersionRange(Version.parse("4.0.0"), true, Version.parse("4.2.0-M1"), false));
     }
 }


### PR DESCRIPTION
## Problem

The scheduled `Update Spring Cloud Azure Support File` workflow regenerates `spring-cloud-azure-supported-spring.json` (consumed by the Spring compatibility tests in `azure-sdk-for-java`). A recent run ([run #29813598533](https://github.com/Azure/spring-cloud-azure-tools/actions/runs/29813598533)) produced [Azure/azure-sdk-for-java#49874](https://github.com/Azure/azure-sdk-for-java/pull/49874), which changed the still-**SUPPORTED** Spring Boot `3.5.16` entry from `"spring-cloud-version": "2025.0.3"` to `"NONE_SUPPORTED_SPRING_CLOUD_VERSION"`.

### Root cause

`findCompatibleSpringCloudVersion` resolves the Spring Cloud version from Spring Initializr (`start.spring.io/actuator/info` -> `bom-ranges.spring-cloud`). Initializr only exposes ranges for the Spring Boot generations it currently offers. Once it moved its default to Spring Boot 4.x, the `spring-cloud` bom shrank to a single entry (`2025.1.2 -> Spring Boot >=4.0.0 and <4.2.0-M1`). Spring Boot `3.5.16` matches no range, so the lookup returned `NONE_SUPPORTED_SPRING_CLOUD_VERSION`.

Only the newest **SUPPORTED** patch of the 3.5.x line was affected; the older 3.5.x entries are `END_OF_LIFE` and already retain their recorded value via the existing branch.

## Fix

In `findCompatibleSpringCloudVersion`, when the Initializr lookup yields no match, fall back instead of regressing to `NONE`:

1. Reuse the last known Spring Cloud version recorded for the **same Spring Boot version** (from the existing support file).
2. Otherwise reuse the **highest known Spring Cloud version from the same `MAJOR.MINOR` line** (covers a brand-new patch of an older line with no recorded entry yet).
3. Only return `NONE_SUPPORTED_SPRING_CLOUD_VERSION` when neither is available.

A successful Initializr match still takes precedence, so a supported line still auto-upgrades to a newer Spring Cloud train patch - no regression.

## Testing

- `mvn test -Dtest=UpdateSpringCloudAzureSupportFileRunnerTest` -> 12/12 pass (5 new tests: reported bug, no-regression auto-upgrade, same-minor-line fallback + negative case, `END_OF_LIFE` retention).
- Dry run against live metadata regenerates the file with `3.5.16 -> 2025.0.3` and zero `NONE_SUPPORTED_SPRING_CLOUD_VERSION` entries.
