### PR TITLE
Upgrade for Spring Cloud Azure 6.5.0/7.4.0

### DIFF
--- a/spring-reference-intellij/spring-reference.yaml
+++ b/spring-reference-intellij/spring-reference.yaml
@@ -8,11 +8,11 @@
     artifacts:
     - artifactId: spring-cloud-azure-dependencies
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: Bill of Materials (BOM) for Spring Cloud Azure support.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/boms/spring-cloud-azure-dependencies
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/boms/spring-cloud-azure-dependencies
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/spring-cloud-azure#bill-of-material-bom
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-dependencies
       dependencyPattern:
@@ -36,7 +36,7 @@
             </dependencyManagement>
       springProperties:
         starter: false
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -73,11 +73,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-dependencies
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-dependencies
-          version: 7.3.0
+          version: 7.4.0
 - name: Active Directory
   content:
   - name: Active Directory
@@ -88,7 +88,7 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-active-directory
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter provides the most optimal way to connect your Web
         application to an Azure Active Directory (AAD for short) tenant and protect resource
@@ -96,14 +96,14 @@
         servers.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-active-directory
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-active-directory
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/configure-spring-boot-starter-java-app-with-azure-active-directory
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-active-directory
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/aad/spring-cloud-azure-starter-active-directory/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/aad/spring-cloud-azure-starter-active-directory/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -140,11 +140,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-active-directory
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-active-directory
-          version: 7.3.0
+          version: 7.4.0
 - name: Active Directory B2C
   content:
   - name: Active Directory B2C
@@ -156,17 +156,17 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-active-directory-b2c
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-active-directory-b2c
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-active-directory-b2c
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/configure-spring-boot-starter-java-app-with-azure-active-directory-b2c-oidc
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-active-directory-b2c
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/aad/spring-cloud-azure-starter-active-directory-b2c/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/aad/spring-cloud-azure-starter-active-directory-b2c/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -203,11 +203,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-active-directory-b2c
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-active-directory-b2c
-          version: 7.3.0
+          version: 7.4.0
 - name: App Configuration
   content:
   - name: App Configuration
@@ -222,20 +222,20 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-appconfiguration
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Azure App Configuration.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-appconfiguration
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-appconfiguration
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/spring-cloud-azure#auto-configure-azure-sdk-clients
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-appconfiguration
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/appconfiguration/spring-cloud-azure-starter-appconfiguration/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/appconfiguration/spring-cloud-azure-starter-appconfiguration/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -272,25 +272,25 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-appconfiguration
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-appconfiguration
-          version: 7.3.0
+          version: 7.4.0
     - artifactId: spring-cloud-azure-starter-appconfiguration-config
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: Microsoft's Spring Boot Starter helps developers to load properties
         and manage features from Azure App Configuration service for Spring Application.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-appconfiguration-config
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-appconfiguration-config
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-appconfiguration-config
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/appconfiguration/spring-cloud-azure-starter-appconfiguration-config/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/appconfiguration/spring-cloud-azure-starter-appconfiguration-config/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -327,11 +327,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-appconfiguration-config
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-appconfiguration-config
-          version: 7.3.0
+          version: 7.4.0
 - name: Cosmos DB
   content:
   - name: Spring Data Cosmos
@@ -347,21 +347,21 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-data-cosmos
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Spring Data Azure Cosmos DB, which enables developers to easily integrate with Azure Cosmos
         DB SQL API using Spring Data.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-data-cosmos
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-data-cosmos
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/configure-spring-boot-starter-java-app-with-cosmos-db
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-data-cosmos
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/cosmos/spring-cloud-azure-starter-data-cosmos/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/cosmos/spring-cloud-azure-starter-data-cosmos/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -398,11 +398,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-data-cosmos
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-data-cosmos
-          version: 7.3.0
+          version: 7.4.0
   - name: Cosmos DB
     description: |-
       Azure Cosmos DB is a fully managed NoSQL database for modern app development.
@@ -413,20 +413,20 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-cosmos
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Azure Cosmos DB, which enables developers to easily integrate with Azure Cosmos DB SQL API.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-cosmos
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-cosmos
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/spring-cloud-azure#auto-configure-azure-sdk-clients
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-cosmos
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/cosmos/spring-cloud-azure-starter-cosmos/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/cosmos/spring-cloud-azure-starter-cosmos/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -463,11 +463,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-cosmos
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-cosmos
-          version: 7.3.0
+          version: 7.4.0
 - name: Key Vault
   content:
   - name: Key Vault
@@ -477,20 +477,20 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-keyvault
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Azure Key Vault.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-keyvault
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-keyvault
         msdocs: https://learn.microsoft.com/azure/key-vault/
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-keyvault
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/keyvault/spring-cloud-azure-starter-keyvault/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/keyvault/spring-cloud-azure-starter-keyvault/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -527,11 +527,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-keyvault
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-keyvault
-          version: 7.3.0
+          version: 7.4.0
   - name: Key Vault - Certificates
     description: |-
       Azure Key Vault enables Microsoft Azure applications and users to store and use certificates, which are
@@ -543,19 +543,19 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-keyvault-certificates
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Azure Key Vault Certificates.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-keyvault-certificates
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-keyvault-certificates
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/configure-spring-boot-starter-java-app-with-azure-key-vault-certificates
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-keyvault-certificates
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -592,11 +592,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-keyvault-certificates
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-keyvault-certificates
-          version: 7.3.0
+          version: 7.4.0
     - artifactId: azure-security-keyvault-jca
       groupId: com.azure
       versionGA: 2.10.1
@@ -620,7 +620,7 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-keyvault-secrets
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Azure Key Vault Secrets, and adds Azure Key Vault as one of Spring PropertySource.
@@ -628,14 +628,14 @@
         externalized configuration property.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-keyvault-secrets
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-keyvault-secrets
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/configure-spring-boot-starter-java-app-with-azure-key-vault
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-keyvault-secrets
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/keyvault/spring-cloud-azure-starter-keyvault-secrets/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/keyvault/spring-cloud-azure-starter-keyvault-secrets/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -672,11 +672,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-keyvault-secrets
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-keyvault-secrets
-          version: 7.3.0
+          version: 7.4.0
 - name: Storage
   content:
   - name: Storage
@@ -685,21 +685,21 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-storage
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Azure Storage, and implements Spring Resource abstraction for Azure Storage
         service which allows you to interact with Storage Account using Spring programming model.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-storage
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-storage
         msdocs: https://docs.microsoft.com/azure/storage/
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-storage
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/storage/spring-cloud-azure-starter-storage/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/storage/spring-cloud-azure-starter-storage/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -736,11 +736,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-storage
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-storage
-          version: 7.3.0
+          version: 7.4.0
   - name: Storage - Blobs
     description: |-
       Azure Blob Storage is Microsoft's object storage solution for the cloud. Blob Storage
@@ -754,21 +754,21 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-storage-blob
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Azure Storage Blob, and implements Spring Resource abstraction for Azure Storage
         service which allows you to interact with Storage Blob using Spring programming model.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-storage-blob
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-storage-blob
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/configure-spring-boot-starter-java-app-with-azure-storage
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-storage-blob
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/storage/spring-cloud-azure-starter-storage-blob/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/storage/spring-cloud-azure-starter-storage-blob/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -805,11 +805,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-storage-blob
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-storage-blob
-          version: 7.3.0
+          version: 7.4.0
   - name: Storage - Files Shares
     description: |-
       Azure File Share storage offers fully managed file shares in the cloud that are
@@ -824,21 +824,21 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-storage-file-share
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Azure Storage File Share, and implements Spring Resource abstraction for Azure Storage
         service which allows you to interact with Storage File Share using Spring programming model.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-storage-file-share
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-storage-file-share
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/spring-cloud-azure#resource-handling
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-storage-file-share
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/storage/spring-cloud-azure-starter-storage-file-share/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/storage/spring-cloud-azure-starter-storage-file-share/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -875,11 +875,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-storage-file-share
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-storage-file-share
-          version: 7.3.0
+          version: 7.4.0
   - name: Storage - Queues
     description: |-
       Azure Queue Storage is a service for storing large numbers of messages. You access
@@ -894,20 +894,20 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-storage-queue
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Azure Storage Queue.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-storage-queue
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-storage-queue
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/spring-cloud-azure#auto-configure-azure-sdk-clients
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-storage-queue
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/storage/spring-cloud-azure-starter-storage-queue/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/storage/spring-cloud-azure-starter-storage-queue/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -944,27 +944,27 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-storage-queue
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-storage-queue
-          version: 7.3.0
+          version: 7.4.0
     - artifactId: spring-cloud-azure-starter-integration-storage-queue
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Spring Integration Azure Storage Queue.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-integration-storage-queue
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-integration-storage-queue
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/configure-spring-boot-starter-java-app-with-azure-service-bus
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-integration-storage-queue
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/storage/spring-cloud-azure-starter-integration-storage-queue/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/storage/spring-cloud-azure-starter-integration-storage-queue/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -1001,28 +1001,28 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-integration-storage-queue
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-integration-storage-queue
-          version: 7.3.0
+          version: 7.4.0
     - artifactId: spring-integration-azure-storage-queue
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Integration extension for Azure Storage Queue. Spring Integration extends
         the Spring programming model to support well-known Enterprise Integration Patterns.
       type: spring
       links:
-        javadoc: https://azuresdkdocs.z19.web.core.windows.net/java/spring-integration-azure-storage-queue/7.3.0/index.html
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-integration-azure-storage-queue
+        javadoc: https://azuresdkdocs.z19.web.core.windows.net/java/spring-integration-azure-storage-queue/7.4.0/index.html
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-integration-azure-storage-queue
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/spring-cloud-azure#spring-integration-support
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-integration-azure-storage-queue
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/storage/spring-integration-azure-storage-queue/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/storage/spring-integration-azure-storage-queue/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -1059,11 +1059,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-integration-azure-storage-queue
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-integration-azure-storage-queue
-          version: 7.3.0
+          version: 7.4.0
 - name: Service Bus
   content:
   - name: Service Bus
@@ -1079,20 +1079,20 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-servicebus
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Azure Service Bus.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-servicebus
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-servicebus
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/spring-cloud-azure#auto-configure-azure-sdk-clients
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-servicebus
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/servicebus/spring-cloud-azure-starter-servicebus/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/servicebus/spring-cloud-azure-starter-servicebus/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -1129,27 +1129,27 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-servicebus
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-servicebus
-          version: 7.3.0
+          version: 7.4.0
     - artifactId: spring-cloud-azure-starter-integration-servicebus
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Spring Integration Azure Service Bus.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-integration-servicebus
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-integration-servicebus
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/configure-spring-boot-starter-java-app-with-azure-service-bus
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-integration-servicebus
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/servicebus/spring-cloud-azure-starter-integration-servicebus/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/servicebus/spring-cloud-azure-starter-integration-servicebus/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -1186,28 +1186,28 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-integration-servicebus
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-integration-servicebus
-          version: 7.3.0
+          version: 7.4.0
     - artifactId: spring-integration-azure-servicebus
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Integration extension for Azure Service Bus. Spring Integration extends
         the Spring programming model to support well-known Enterprise Integration Patterns.
       type: spring
       links:
-        javadoc: https://azuresdkdocs.z19.web.core.windows.net/java/spring-integration-azure-servicebus/7.3.0/index.html
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-integration-azure-servicebus
+        javadoc: https://azuresdkdocs.z19.web.core.windows.net/java/spring-integration-azure-servicebus/7.4.0/index.html
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-integration-azure-servicebus
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/spring-cloud-azure#spring-integration-support
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-integration-azure-servicebus
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/servicebus/spring-integration-azure-servicebus/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/servicebus/spring-integration-azure-servicebus/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -1244,29 +1244,29 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-integration-azure-servicebus
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-integration-azure-servicebus
-          version: 7.3.0
+          version: 7.4.0
     - artifactId: spring-cloud-azure-stream-binder-servicebus
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Cloud Stream Binder provides Spring Cloud Stream Binder for Azure
         Service Bus which allows you to build message-driven microservice using Spring Cloud
         Stream based on Azure Service Bus.
       type: spring
       links:
-        javadoc: https://azuresdkdocs.z19.web.core.windows.net/java/spring-cloud-azure-stream-binder-servicebus/7.3.0/index.html
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-stream-binder-servicebus
+        javadoc: https://azuresdkdocs.z19.web.core.windows.net/java/spring-cloud-azure-stream-binder-servicebus/7.4.0/index.html
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-stream-binder-servicebus
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/configure-spring-cloud-stream-binder-java-app-with-service-bus
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-stream-binder-servicebus
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/servicebus/spring-cloud-azure-stream-binder-servicebus/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/servicebus/spring-cloud-azure-stream-binder-servicebus/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -1303,11 +1303,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-stream-binder-servicebus
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-stream-binder-servicebus
-          version: 7.3.0
+          version: 7.4.0
   - name: Service Bus JMS
     description: |-
       Microsoft Azure Service Bus is a fully managed enterprise integration message broker.
@@ -1318,20 +1318,20 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-servicebus-jms
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Spring JMS with Azure Service Bus Queue and Topic.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-servicebus-jms
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-servicebus-jms
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/configure-spring-boot-starter-java-app-with-azure-service-bus
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-servicebus-jms
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/servicebus/spring-cloud-azure-starter-servicebus-jms/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/servicebus/spring-cloud-azure-starter-servicebus-jms/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -1368,11 +1368,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-servicebus-jms
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-servicebus-jms
-          version: 7.3.0
+          version: 7.4.0
 - name: Event Grid
   content:
   - name: Event Grid
@@ -1394,20 +1394,20 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-eventgrid
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Azure Event Grid.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-eventgrid
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-eventgrid
         msdocs: https://learn.microsoft.com/azure/developer/java/spring-framework/configure-spring-boot-initializer-java-app-with-event-grid
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-eventgrid
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/eventgrid/spring-cloud-azure-starter-eventgrid/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/eventgrid/spring-cloud-azure-starter-eventgrid/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -1444,11 +1444,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-eventgrid
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-eventgrid
-          version: 7.3.0
+          version: 7.4.0
 - name: Event Hubs
   content:
   - name: Event Hubs
@@ -1464,20 +1464,20 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-eventhubs
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Azure Event Hubs.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-eventhubs
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-eventhubs
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/spring-cloud-azure#auto-configure-azure-sdk-clients
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-eventhubs
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/eventhubs/spring-cloud-azure-starter-eventhubs/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/eventhubs/spring-cloud-azure-starter-eventhubs/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -1514,27 +1514,27 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-eventhubs
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-eventhubs
-          version: 7.3.0
+          version: 7.4.0
     - artifactId: spring-cloud-azure-starter-integration-eventhubs
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Spring Integration Azure Event Hubs.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-integration-eventhubs
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-integration-eventhubs
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/configure-spring-boot-starter-java-app-with-azure-service-bus
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-integration-eventhubs
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/eventhubs/spring-cloud-azure-starter-integration-eventhubs/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/eventhubs/spring-cloud-azure-starter-integration-eventhubs/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -1571,28 +1571,28 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-integration-eventhubs
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-integration-eventhubs
-          version: 7.3.0
+          version: 7.4.0
     - artifactId: spring-integration-azure-eventhubs
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Integration extension for Azure Event Hubs. Spring Integration extends
         the Spring programming model to support well-known Enterprise Integration Patterns.
       type: spring
       links:
-        javadoc: https://azuresdkdocs.z19.web.core.windows.net/java/spring-integration-azure-eventhubs/7.3.0/index.html
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-integration-azure-eventhubs
+        javadoc: https://azuresdkdocs.z19.web.core.windows.net/java/spring-integration-azure-eventhubs/7.4.0/index.html
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-integration-azure-eventhubs
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/spring-cloud-azure#spring-integration-support
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-integration-azure-eventhubs
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/eventhubs/spring-integration-azure-eventhubs/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/eventhubs/spring-integration-azure-eventhubs/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -1629,29 +1629,29 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-integration-azure-eventhubs
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-integration-azure-eventhubs
-          version: 7.3.0
+          version: 7.4.0
     - artifactId: spring-cloud-azure-stream-binder-eventhubs
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Cloud Stream Binder provides Spring Cloud Stream Binder for Azure
         Event Hubs which allows you to build message-driven microservice using Spring Cloud
         Stream based on Azure Event Hubs.
       type: spring
       links:
-        javadoc: https://azuresdkdocs.z19.web.core.windows.net/java/spring-cloud-azure-stream-binder-eventhubs/7.3.0/index.html
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-stream-binder-eventhubs
+        javadoc: https://azuresdkdocs.z19.web.core.windows.net/java/spring-cloud-azure-stream-binder-eventhubs/7.4.0/index.html
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-stream-binder-eventhubs
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/spring-cloud-azure#spring-cloud-stream-binder-for-azure-event-hubs
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-stream-binder-eventhubs
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/eventhubs/spring-cloud-azure-stream-binder-eventhubs/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/eventhubs/spring-cloud-azure-stream-binder-eventhubs/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -1688,11 +1688,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-stream-binder-eventhubs
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-stream-binder-eventhubs
-          version: 7.3.0
+          version: 7.4.0
 - name: MySQL
   content:
   - name: Database for MySQL
@@ -1704,20 +1704,20 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-jdbc-mysql
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Azure Database for MySQL.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-jdbc-mysql
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-jdbc-mysql
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/spring-cloud-azure#auto-configure-azure-sdk-clients
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-jdbc-mysql
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/mysql/spring-cloud-azure-starter-jdbc-mysql/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/mysql/spring-cloud-azure-starter-jdbc-mysql/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -1754,11 +1754,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-jdbc-mysql
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-jdbc-mysql
-          version: 7.3.0
+          version: 7.4.0
 - name: PostgreSQL
   content:
   - name: Database for PostgreSQL
@@ -1770,20 +1770,20 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-jdbc-postgresql
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Azure Database for PostgreSQL.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-jdbc-postgresql
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-jdbc-postgresql
         msdocs: https://docs.microsoft.com/azure/developer/java/spring-framework/spring-cloud-azure#auto-configure-azure-sdk-clients
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-jdbc-postgresql
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/postgresql/spring-cloud-azure-starter-jdbc-postgresql/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/postgresql/spring-cloud-azure-starter-jdbc-postgresql/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[2.5.0,4.0.6]"
+        compatibilityRange: "[2.5.0,4.1.0]"
         mappings:
         - compatibilityRange: "[2.5.0,2.5.15]"
           groupId: com.azure.spring
@@ -1820,11 +1820,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-jdbc-postgresql
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-jdbc-postgresql
-          version: 7.3.0
+          version: 7.4.0
 - name: Redis
   content:
   - name: Azure Cache for Redis
@@ -1839,20 +1839,20 @@
     artifacts:
     - artifactId: spring-cloud-azure-starter-data-redis-lettuce
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Boot Starter helps developers to finish the auto-configuration of
         Azure Cache for Redis.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-starter-data-redis-lettuce
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-starter-data-redis-lettuce
         msdocs: https://learn.microsoft.com/azure/developer/java/spring-framework/configure-spring-boot-initializer-java-app-with-redis-cache
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-starter-data-redis-lettuce
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/redis/spring-cloud-azure-starter-data-redis-lettuce/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/redis/spring-cloud-azure-starter-data-redis-lettuce/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[3.0.0,4.0.6]"
+        compatibilityRange: "[3.0.0,4.1.0]"
         mappings:
         - compatibilityRange: "[3.0.0,3.0.13]"
           groupId: com.azure.spring
@@ -1877,11 +1877,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-data-redis-lettuce
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-starter-data-redis-lettuce
-          version: 7.3.0
+          version: 7.4.0
 - name: Testcontainers
   content:
   - name: Testcontainers
@@ -1893,19 +1893,19 @@
     artifacts:
     - artifactId: spring-cloud-azure-testcontainers
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Cloud Azure lib helps developers to use testcontainers to test Cosmos,
         Storage Blob, Storage Queue.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-testcontainers
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-testcontainers
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-testcontainers
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/testcontainers/spring-cloud-azure-testcontainers/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/testcontainers/spring-cloud-azure-testcontainers/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[3.0.0,4.0.6]"
+        compatibilityRange: "[3.0.0,4.1.0]"
         mappings:
         - compatibilityRange: "[3.0.0,3.0.13]"
           groupId: com.azure.spring
@@ -1930,11 +1930,11 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-testcontainers
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-testcontainers
-          version: 7.3.0
+          version: 7.4.0
 - name: Dockercompose
   content:
   - name: Dockercompose
@@ -1947,19 +1947,19 @@
     artifacts:
     - artifactId: spring-cloud-azure-docker-compose
       groupId: com.azure.spring
-      versionGA: 7.3.0
+      versionGA: 7.4.0
       description: |-
         Microsoft's Spring Cloud Azure lib helps developers to use Docker Compose, now it
         supports Azure Storage Blob and Azure Storage Queue.
       type: spring
       links:
-        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.3.0/sdk/spring/spring-cloud-azure-docker-compose
+        github: https://github.com/Azure/azure-sdk-for-java/tree/spring-cloud-azure_7.4.0/sdk/spring/spring-cloud-azure-docker-compose
         repopath: https://search.maven.org/artifact/com.azure.spring/spring-cloud-azure-docker-compose
-        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.3.0/dockercompose/spring-cloud-azure-docker-compose/
+        sample: https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_7.4.0/dockercompose/spring-cloud-azure-docker-compose/
       springProperties:
         starter: true
         bom: spring-cloud-azure-dependencies
-        compatibilityRange: "[3.0.0,4.0.6]"
+        compatibilityRange: "[3.0.0,4.1.0]"
         mappings:
         - compatibilityRange: "[3.0.0,3.0.13]"
           groupId: com.azure.spring
@@ -1984,8 +1984,8 @@
         - compatibilityRange: "[3.5.0,3.5.14]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-docker-compose
-          version: 6.4.0
-        - compatibilityRange: "[4.0.0,4.0.6]"
+          version: 6.5.0
+        - compatibilityRange: "[4.0.0,4.1.0]"
           groupId: com.azure.spring
           artifactId: spring-cloud-azure-docker-compose
-          version: 7.3.0
+          version: 7.4.0

--- a/spring-reference-intellij/src/main/resources/application.yaml
+++ b/spring-reference-intellij/src/main/resources/application.yaml
@@ -550,7 +550,7 @@ spring.cloud.azure.reference:
   compatibilities:
     - artifact-id: spring-cloud-azure-dependencies
       lowest-spring-boot-version: 2.5.0
-      highest-spring-boot-version: 4.0.6
+      highest-spring-boot-version: 4.1.0
       mappings:
         - lowest-spring-boot-version: 2.5.0
           highest-spring-boot-version: 2.5.15
@@ -578,13 +578,13 @@ spring.cloud.azure.reference:
           version: 5.25.0
         - lowest-spring-boot-version: 3.5.0
           highest-spring-boot-version: 3.5.14
-          version: 6.4.0
+          version: 6.5.0
         - lowest-spring-boot-version: 4.0.0
-          highest-spring-boot-version: 4.0.6
-          version: 7.3.0
+          highest-spring-boot-version: 4.1.0
+          version: 7.4.0
     - artifact-id: spring-cloud-azure-starter-data-redis-lettuce
       lowest-spring-boot-version: 3.0.0
-      highest-spring-boot-version: 4.0.6
+      highest-spring-boot-version: 4.1.0
       mappings:
         - lowest-spring-boot-version: 3.0.0
           highest-spring-boot-version: 3.0.13
@@ -603,13 +603,13 @@ spring.cloud.azure.reference:
           version: 5.25.0
         - lowest-spring-boot-version: 3.5.0
           highest-spring-boot-version: 3.5.14
-          version: 6.4.0
+          version: 6.5.0
         - lowest-spring-boot-version: 4.0.0
-          highest-spring-boot-version: 4.0.6
-          version: 7.3.0
+          highest-spring-boot-version: 4.1.0
+          version: 7.4.0
     - artifact-id: spring-cloud-azure-testcontainers
       lowest-spring-boot-version: 3.0.0
-      highest-spring-boot-version: 4.0.6
+      highest-spring-boot-version: 4.1.0
       mappings:
         - lowest-spring-boot-version: 3.0.0
           highest-spring-boot-version: 3.0.13
@@ -628,13 +628,13 @@ spring.cloud.azure.reference:
           version: 5.25.0
         - lowest-spring-boot-version: 3.5.0
           highest-spring-boot-version: 3.5.14
-          version: 6.4.0
+          version: 6.5.0
         - lowest-spring-boot-version: 4.0.0
-          highest-spring-boot-version: 4.0.6
-          version: 7.3.0
+          highest-spring-boot-version: 4.1.0
+          version: 7.4.0
     - artifact-id: spring-cloud-azure-docker-compose
       lowest-spring-boot-version: 3.0.0
-      highest-spring-boot-version: 4.0.6
+      highest-spring-boot-version: 4.1.0
       mappings:
         - lowest-spring-boot-version: 3.0.0
           highest-spring-boot-version: 3.0.13
@@ -653,13 +653,13 @@ spring.cloud.azure.reference:
           version: 5.25.0
         - lowest-spring-boot-version: 3.5.0
           highest-spring-boot-version: 3.5.14
-          version: 6.4.0
+          version: 6.5.0
         - lowest-spring-boot-version: 4.0.0
-          highest-spring-boot-version: 4.0.6
-          version: 7.3.0
+          highest-spring-boot-version: 4.1.0
+          version: 7.4.0
   versions:
     - artifact-id: spring-cloud-azure-dependencies
-      ga-version: 7.3.0
+      ga-version: 7.4.0
     - artifact-id: azure-security-keyvault-jca
       ga-version: 2.10.1
 


### PR DESCRIPTION
Update `application.yaml` for the released Spring Cloud Azure 6.5.0 / 7.4.0, and regenerate `spring-reference.yaml` by running `spring-reference-intellij`.

Changes in `application.yaml`:
- `spring-cloud-azure-dependencies` GA version: 7.3.0 -> 7.4.0.
- Spring Boot 3.5.x mapping: Spring Cloud Azure 6.4.0 -> 6.5.0.
- Spring Boot 4.x mapping: `[4.0.0,4.0.6]` -> `[4.0.0,4.1.0]`, Spring Cloud Azure 7.3.0 -> 7.4.0.
- Highest supported Spring Boot version: 4.0.6 -> 4.1.0.

The compatibility ranges follow the release notes in [sdk/spring/CHANGELOG.md](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/spring/CHANGELOG.md): 7.4.0 is compatible with Spring Boot 4.0.0-4.1.0, and 6.5.0 is compatible with Spring Boot 3.5.0-3.5.14.

The regenerated `spring-reference.yaml` will be synchronized to `sdk/spring/spring-reference.yml` in the azure-sdk-for-java repository.